### PR TITLE
docs: update cds-api host port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ services:
       dockerfile: Dockerfile
     container_name: cds-api
     ports:
-      - "8080:8080"
+      - "8081:8080"
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
**Related issue**
#9

**Summary**
Update the README Docker Compose example to expose `cds-api` on host port `8081` instead of `8080`.

**What changed**
- Changed `cds-api` port mapping from `8080:8080` to `8081:8080`

**Impact**
- Direct host access to `cds-api` changes from `localhost:8080` to `localhost:8081`
- Container-to-container traffic remains unchanged; `cds-api` still listens on container port `8080`
- Avoids conflict with services already using host port `8080`