### PR TITLE
Implement Keycloak DPoP auth for CDS admin APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.22'
+          cache-dependency-path: cds_service/go.sum
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,18 @@ jobs:
           --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:password@localhost:5432/cds_test?sslmode=disable
+      AUTH_MODE: keycloak-dpop
+      KEYCLOAK_ISSUER_URL: https://keycloak.example.com/realms/cds
+      KEYCLOAK_JWKS_URL: https://keycloak.example.com/realms/cds/protocol/openid-connect/certs
+      KEYCLOAK_AUDIENCE: cds-service
+      KEYCLOAK_REQUIRED_ROLE: cds-admin
+      KEYCLOAK_ADMIN_UI_CLIENT_ID: cds-admin-ui
+      DPOP_REQUIRED: "true"
+      DPOP_JTI_CACHE_TTL_SECONDS: "300"
+      DPOP_PROOF_MAX_AGE_SECONDS: "300"
+      DPOP_CLOCK_SKEW_SECONDS: "30"
+      JWKS_CACHE_TTL_SECONDS: "300"
+      TRUSTED_PROXY_CIDRS: 10.0.0.0/8,127.0.0.1/32
 
     defaults:
       run:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This service runs Go APIs (PostgreSQL-backed) fronted by Nginx (TLS).
 `ra-cds-service` exposes HTTPS APIs to:
 
 -   Manage devices (add, update, delete, list) using the unified `/v1/device` admin API.
+    - `DELETE` uses `/v1/device/{serial}`.
 -   Serves the device → controller endpoint mappings.
 
 
@@ -152,7 +153,7 @@ CREATE TABLE IF NOT EXISTS public.devices (
   controller_endpoint TEXT NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-  owner_token TEXT
+  owner_scope TEXT
 );
 
 -- Lowercase serial
@@ -181,9 +182,6 @@ CREATE TRIGGER set_updated_at
 BEFORE UPDATE ON public.devices
 FOR EACH ROW EXECUTE PROCEDURE trg_set_updated_at();
 
--- Ensure column exists if old DB (idempotent)
-ALTER TABLE public.devices
-  ADD COLUMN IF NOT EXISTS owner_token TEXT;
 ```
 
 ### `cds_deploy/nginx/Dockerfile`
@@ -216,7 +214,7 @@ server {
     }
 }
 
-# Admin-facing API (no client cert)
+# Admin-facing API (no client cert, Keycloak DPoP headers are forwarded)
 server {
     listen 5443 ssl;
     server_name localhost;
@@ -225,7 +223,10 @@ server {
     ssl_certificate_key    /etc/ssl/private/server-key.pem;
     ssl_verify_client      off;
 
-    location = /v1/device {
+    location /v1/device {
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header X-Forwarded-Port  $server_port;
         proxy_pass http://cds-api:8080;
     }
 }
@@ -239,14 +240,35 @@ POSTGRES_DSN=postgres://postgres:password@postgres:5432/cds?sslmode=disable
 # Go service listen address (must match EXPOSE 8080)
 HTTP_ADDR=:8080
 
-# Url to validate security token
-VALIDATE_TOKEN_URL=https://openwifi3.routerarchitects.com:16001/api/v1/validateToken
+# Auth mode
+AUTH_MODE=keycloak-dpop
+
+# Keycloak JWT validation
+KEYCLOAK_ISSUER_URL=https://keycloak.example.com/realms/cds
+KEYCLOAK_JWKS_URL=https://keycloak.example.com/realms/cds/protocol/openid-connect/certs
+KEYCLOAK_AUDIENCE=cds-service
+KEYCLOAK_REQUIRED_ROLE=cds-admin
+KEYCLOAK_ADMIN_UI_CLIENT_ID=cds-admin-ui
+
+# DPoP validation
+DPOP_REQUIRED=true
+DPOP_JTI_CACHE_TTL_SECONDS=300
+DPOP_PROOF_MAX_AGE_SECONDS=300
+DPOP_CLOCK_SKEW_SECONDS=30
+
+# JWKS cache
+JWKS_CACHE_TTL_SECONDS=300
+
+# Trusted proxies for forwarded headers (CDS is behind Nginx in this setup)
+TRUSTED_PROXY_CIDRS=172.16.0.0/12,192.168.0.0/16,10.0.0.0/8
 ```
 ---------
 
 **Note:**
- Set VALIDATE_TOKEN_URL to the exact token-validation endpoint of your deployment(If any).
-The CDS service will call this URL to verify that the provided security-Token is valid.
+Set the Keycloak and DPoP values to your deployment-specific values.
+Admin API requests must include both:
+- `Authorization: DPoP <keycloak_access_token>`
+- `DPoP: <dpop_proof_jwt>`
 
 ## Generate & Place Server Certificates
 
@@ -286,7 +308,7 @@ docker-compose up -d
 
 ```
 docker-compose logs -f postgres
-docker-compose logs -f cds_service
+docker-compose logs -f cds-api
 docker-compose logs -f nginx
 ```
 
@@ -295,29 +317,33 @@ docker-compose logs -f nginx
 ## Verify
 
 ### Important Notes:
-#### Security Token Requirement:
-- The CDS service enforces strict access control.
-- All **add / update / delete / list** operations require a valid security-token belonging to a user with the **root** role.
-- Always make sure you are using a valid root security-token before running any admin operations.
+#### Admin Auth Requirement:
+- The CDS service enforces Keycloak DPoP auth for admin APIs.
+- All **add / update / delete / list** operations require:
+  - `Authorization: DPoP <keycloak_access_token>`
+  - `DPoP: <dpop_proof_jwt>`
+- Access token must include the configured admin role (`KEYCLOAK_REQUIRED_ROLE`) for audience `KEYCLOAK_AUDIENCE`.
 #### API Method Mapping (Admin APIs)
 The admin device API uses a single resource path with method-based routing:
 
 GET    /v1/device        -> list devices
 POST   /v1/device        -> create or upsert device
 PUT    /v1/device        -> update existing device
-DELETE /v1/device        -> delete device
+DELETE /v1/device/{serial} -> delete device
 
 ### Add device
 
 ```
 curl -k -X POST https://localhost:5443/v1/device \
-  -H "X-Auth-Token: <use valid root security-token here>" \
+  -H "Authorization: DPoP <keycloak_access_token>" \
+  -H "DPoP: <dpop_proof_jwt>" \
   -H "Content-Type: application/json" \
   -d '{"serial":"<device-serial-no.>", "controller_endpoint":"<controller-url>"}'
 
 Ex:
 curl -k -X POST https://localhost:5443/v1/device \
-  -H "X-Auth-Token: <use valid root security-token here>" \
+  -H "Authorization: DPoP <keycloak_access_token>" \
+  -H "DPoP: <dpop_proof_jwt>" \
   -H "Content-Type: application/json" \
   -d '{"serial":"b4:6a:d4:45:f0:19", "controller_endpoint":"openwifi3.routerarchitects.com"}'
 ```
@@ -326,7 +352,8 @@ curl -k -X POST https://localhost:5443/v1/device \
 
 ```
 curl -k -X PUT https://localhost:5443/v1/device \
-  -H "X-Auth-Token: <use valid root security-token here>" \
+  -H "Authorization: DPoP <keycloak_access_token>" \
+  -H "DPoP: <dpop_proof_jwt>" \
   -H "Content-Type: application/json" \
   -d '{"serial":"b4:6a:d4:45:f0:19", "controller_endpoint":"openwifi3.routerarchitects.com"}'
   ```
@@ -334,17 +361,17 @@ curl -k -X PUT https://localhost:5443/v1/device \
 ### Delete device
 
 ```
-curl -k -X DELETE https://localhost:5443/v1/device \
-  -H "X-Auth-Token: <use valid root security-token here>" \
-  -H "Content-Type: application/json" \
-  -d '{"serial":"b4:6a:d4:45:f0:19"}'
+curl -k -X DELETE "https://localhost:5443/v1/device/b4:6a:d4:45:f0:19" \
+  -H "Authorization: DPoP <keycloak_access_token>" \
+  -H "DPoP: <dpop_proof_jwt>"
 ```
 
-### List all devices (Added with security token)
+### List all devices (admin DPoP request)
 
 ```
 curl -k https://localhost:5443/v1/device \
-  -H "X-Auth-Token: <use valid root security-token here>"
+  -H "Authorization: DPoP <keycloak_access_token>" \
+  -H "DPoP: <dpop_proof_jwt>"
 ```
 
 ### Get controller url from device serial no.(Use device operational certs for mTLS)
@@ -368,7 +395,7 @@ curl -k https://localhost:4443/v1/devices/b4:6a:d4:45:f0:19 \
   `/etc/init.d/cloud_rescovery restart`
 **Expected Behaviour:**
 Response will be stored in gateway.json if already there is entry for device
-serial no.in db with a valid security token.
+serial no.in db.
 ----------
 
 
@@ -392,4 +419,3 @@ serial no.in db with a valid security token.
 ## License
 - SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
 - Copyright (c) 2025 Infernet Systems Pvt Ltd
-

--- a/README.md
+++ b/README.md
@@ -264,8 +264,9 @@ JWKS_CACHE_TTL_SECONDS=300
 # KEYCLOAK_JWKS_URL should use HTTPS in deployed environments.
 # HTTP is allowed only for localhost/loopback testing.
 
-# Trusted proxies for forwarded headers (CDS is behind Nginx in this setup)
-TRUSTED_PROXY_CIDRS=172.16.0.0/12,192.168.0.0/16,10.0.0.0/8
+# Trusted proxy CIDRs for forwarded headers.
+# Replace this with the actual Nginx/proxy CIDR for your deployment.
+TRUSTED_PROXY_CIDRS=10.42.3.0/24
 ```
 ---------
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,11 @@ TRUSTED_PROXY_CIDRS=172.16.0.0/12,192.168.0.0/16,10.0.0.0/8
 ---------
 
 **Note:**
+`cds-api` should remain reachable only on the internal network path behind Nginx. CDS trusts
+`X-SSL-Client-Verify` only when the request source IP is within `TRUSTED_PROXY_CIDRS`.
+
+Device-facing lookup is currently global for any successfully mTLS-verified device client. CDS does not bind the verified client certificate identity to the requested `/v1/devices/{serial}` value. Per-device certificate-to-serial authorization is planned as a follow-up hardening step.
+
 Set the Keycloak and DPoP values to your deployment-specific values.
 Admin API requests must include both:
 - `Authorization: DPoP <keycloak_access_token>`

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ services:
       context: ../cds_service
       dockerfile: Dockerfile
     container_name: cds-api
-    ports:
-      - "8081:8080"
+    expose:
+      - "8080"
     env_file:
       - .env
     depends_on:
@@ -249,9 +249,11 @@ KEYCLOAK_JWKS_URL=https://keycloak.example.com/realms/cds/protocol/openid-connec
 KEYCLOAK_AUDIENCE=cds-service
 KEYCLOAK_REQUIRED_ROLE=cds-admin
 KEYCLOAK_ADMIN_UI_CLIENT_ID=cds-admin-ui
+KEYCLOAK_ACCESS_TOKEN_ALG=RS256
 
 # DPoP validation
 DPOP_REQUIRED=true
+DPOP_ALLOWED_ALGS=ES256
 DPOP_JTI_CACHE_TTL_SECONDS=300
 DPOP_PROOF_MAX_AGE_SECONDS=300
 DPOP_CLOCK_SKEW_SECONDS=30
@@ -259,16 +261,23 @@ DPOP_CLOCK_SKEW_SECONDS=30
 # JWKS cache
 JWKS_CACHE_TTL_SECONDS=300
 
+# KEYCLOAK_JWKS_URL should use HTTPS in deployed environments.
+# HTTP is allowed only for localhost/loopback testing.
+
 # Trusted proxies for forwarded headers (CDS is behind Nginx in this setup)
 TRUSTED_PROXY_CIDRS=172.16.0.0/12,192.168.0.0/16,10.0.0.0/8
 ```
 ---------
 
 **Note:**
-`cds-api` should remain reachable only on the internal network path behind Nginx. CDS trusts
-`X-SSL-Client-Verify` only when the request source IP is within `TRUSTED_PROXY_CIDRS`.
+`cds-api` must stay internal and should only be reachable through Nginx/trusted proxies. Use
+Docker internal networking, firewall rules, or Kubernetes NetworkPolicy to prevent direct client
+access. CDS trusts `X-SSL-Client-Verify` only when the request source IP is within
+`TRUSTED_PROXY_CIDRS`.
 
 Device-facing lookup is currently global for any successfully mTLS-verified device client. CDS does not bind the verified client certificate identity to the requested `/v1/devices/{serial}` value. Per-device certificate-to-serial authorization is planned as a follow-up hardening step.
+
+DPoP replay protection uses an in-memory `jti` cache and is instance-local. It is supported for single-instance CDS deployments only; multi-instance deployments require a shared cache, such as Redis.
 
 Set the Keycloak and DPoP values to your deployment-specific values.
 Admin API requests must include both:

--- a/cds_service/cmd/app/main.go
+++ b/cds_service/cmd/app/main.go
@@ -5,26 +5,25 @@
 package main
 
 import (
-    "log"
-    "net/http"
+	"log"
+	"net/http"
 
-    "cds/internal/app"
-    "cds/internal/config"
+	"cds/internal/app"
+	"cds/internal/config"
 )
 
 func main() {
-    cfg, err := config.Load()
-    if err != nil {
-        log.Fatal(err)
-    }
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    a, err := app.Init(cfg)
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer a.DB.Close()
+	a, err := app.Init(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer a.DB.Close()
 
-    log.Printf("CDS unified API listening on %s", cfg.HTTPAddr)
-    log.Fatal(http.ListenAndServe(cfg.HTTPAddr, a.Mux))
+	log.Printf("CDS unified API listening on %s", cfg.HTTPAddr)
+	log.Fatal(http.ListenAndServe(cfg.HTTPAddr, a.Mux))
 }
-

--- a/cds_service/internal/adapters/logger/logrus_logger.go
+++ b/cds_service/internal/adapters/logger/logrus_logger.go
@@ -55,4 +55,3 @@ func (l *Logrus) Errorf(f string, a ...any) { l.l.Errorf(f, a...) }
 func (l *Logrus) WithField(k string, v any) *Logrus {
 	return &Logrus{l: l.l.WithField(k, v)}
 }
-

--- a/cds_service/internal/adapters/postgres/devices_repo.go
+++ b/cds_service/internal/adapters/postgres/devices_repo.go
@@ -29,14 +29,14 @@ func (r *Repo) GetEndpointBySerial(ctx context.Context, serial string) (string, 
 	return controllerEndpoint, nil
 }
 
-// Admin-facing (scoped to owner token)
+// Admin-facing (scoped to owner scope)
 func (r *Repo) AddDevice(ctx context.Context, serial, controllerEndpoint, owner string) error {
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO public.devices (serial, controller_endpoint, owner_token)
+		`INSERT INTO public.devices (serial, controller_endpoint, owner_scope)
          VALUES (lower($1), $2, $3)
          ON CONFLICT (serial) DO UPDATE
            SET controller_endpoint = EXCLUDED.controller_endpoint,
-               owner_token = EXCLUDED.owner_token`,
+               owner_scope = EXCLUDED.owner_scope`,
 		serial, controllerEndpoint, owner)
 	return err
 }
@@ -45,7 +45,7 @@ func (r *Repo) UpdateDevice(ctx context.Context, serial, controllerEndpoint, own
 	res, err := r.db.ExecContext(ctx,
 		`UPDATE public.devices
            SET controller_endpoint=$2
-         WHERE serial=lower($1) AND owner_token=$3`,
+         WHERE serial=lower($1) AND owner_scope=$3`,
 		serial, controllerEndpoint, owner)
 	if err != nil {
 		return err
@@ -58,7 +58,7 @@ func (r *Repo) UpdateDevice(ctx context.Context, serial, controllerEndpoint, own
 
 func (r *Repo) DeleteDevice(ctx context.Context, serial, owner string) error {
 	res, err := r.db.ExecContext(ctx,
-		`DELETE FROM public.devices WHERE serial=lower($1) AND owner_token=$2`,
+		`DELETE FROM public.devices WHERE serial=lower($1) AND owner_scope=$2`,
 		serial, owner)
 	if err != nil {
 		return err
@@ -73,7 +73,7 @@ func (r *Repo) ListDevicesByOwner(ctx context.Context, owner string) ([]map[stri
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT serial, controller_endpoint
            FROM public.devices
-          WHERE owner_token=$1
+          WHERE owner_scope=$1
           ORDER BY serial ASC`, owner)
 	if err != nil {
 		return nil, err
@@ -93,4 +93,3 @@ func (r *Repo) ListDevicesByOwner(ctx context.Context, owner string) ([]map[stri
 	}
 	return res, rows.Err()
 }
-

--- a/cds_service/internal/adapters/postgres/devices_repo.go
+++ b/cds_service/internal/adapters/postgres/devices_repo.go
@@ -14,6 +14,8 @@ type Repo struct{ db *sql.DB }
 
 func NewRepo(db *sql.DB) *Repo { return &Repo{db: db} }
 
+var ErrDeviceOwnerConflict = errors.New("device already exists for another owner")
+
 // Device-facing lookup (no owner check)
 func (r *Repo) GetEndpointBySerial(ctx context.Context, serial string) (string, error) {
 	var controllerEndpoint string
@@ -31,14 +33,20 @@ func (r *Repo) GetEndpointBySerial(ctx context.Context, serial string) (string, 
 
 // Admin-facing (scoped to owner scope)
 func (r *Repo) AddDevice(ctx context.Context, serial, controllerEndpoint, owner string) error {
-	_, err := r.db.ExecContext(ctx,
+	res, err := r.db.ExecContext(ctx,
 		`INSERT INTO public.devices (serial, controller_endpoint, owner_scope)
          VALUES (lower($1), $2, $3)
          ON CONFLICT (serial) DO UPDATE
-           SET controller_endpoint = EXCLUDED.controller_endpoint,
-               owner_scope = EXCLUDED.owner_scope`,
+           SET controller_endpoint = EXCLUDED.controller_endpoint
+         WHERE public.devices.owner_scope = EXCLUDED.owner_scope`,
 		serial, controllerEndpoint, owner)
-	return err
+	if err != nil {
+		return err
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return ErrDeviceOwnerConflict
+	}
+	return nil
 }
 
 func (r *Repo) UpdateDevice(ctx context.Context, serial, controllerEndpoint, owner string) error {

--- a/cds_service/internal/app/app.go
+++ b/cds_service/internal/app/app.go
@@ -21,7 +21,7 @@ import (
 
 type App struct {
 	DB  *sql.DB
-	Mux *http.ServeMux
+	Mux http.Handler
 }
 
 func pingWithRetry(db *sql.DB, attempts int, delay time.Duration) error {
@@ -55,4 +55,3 @@ func Init(cfg *config.Config) (*App, error) {
 	log.Infof("Initialized CDS service")
 	return &App{DB: db, Mux: mux}, nil
 }
-

--- a/cds_service/internal/config/config.go
+++ b/cds_service/internal/config/config.go
@@ -7,6 +7,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -22,6 +23,8 @@ type Config struct {
 	KeycloakAudience       string
 	KeycloakRequiredRole   string
 	KeycloakAdminUIClient  string
+	KeycloakAccessTokenAlg string
+	DPoPAllowedAlgs        []string
 	DPoPRequired           bool
 	DPoPJtiCacheTTLSeconds int
 	DPoPProofMaxAgeSeconds int
@@ -60,6 +63,9 @@ func Load() (*Config, error) {
 	if cfg.KeycloakJWKSURL == "" {
 		return nil, fmt.Errorf("KEYCLOAK_JWKS_URL is required")
 	}
+	if err := validateJWKSURL(cfg.KeycloakJWKSURL); err != nil {
+		return nil, err
+	}
 	if cfg.KeycloakAudience == "" {
 		return nil, fmt.Errorf("KEYCLOAK_AUDIENCE is required")
 	}
@@ -68,6 +74,13 @@ func Load() (*Config, error) {
 	}
 	if cfg.KeycloakAdminUIClient == "" {
 		return nil, fmt.Errorf("KEYCLOAK_ADMIN_UI_CLIENT_ID is required")
+	}
+	var err error
+	if cfg.KeycloakAccessTokenAlg, err = parseJWTAlgEnv("KEYCLOAK_ACCESS_TOKEN_ALG", "RS256"); err != nil {
+		return nil, err
+	}
+	if cfg.DPoPAllowedAlgs, err = parseJWTAlgListEnv("DPOP_ALLOWED_ALGS", []string{"ES256"}); err != nil {
+		return nil, err
 	}
 
 	dpopRequired, err := parseBoolEnv("DPOP_REQUIRED", true)
@@ -142,4 +155,71 @@ func parseListEnv(key string) []string {
 		}
 	}
 	return out
+}
+
+func parseJWTAlgEnv(key, fallback string) (string, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		v = fallback
+	}
+	switch v {
+	case "RS256", "ES256":
+		return v, nil
+	default:
+		return "", fmt.Errorf("%s must be one of RS256, ES256", key)
+	}
+}
+
+func parseJWTAlgListEnv(key string, fallback []string) ([]string, error) {
+	raw, set := os.LookupEnv(key)
+	if !set {
+		return fallback, nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		alg := strings.TrimSpace(p)
+		if alg == "" {
+			continue
+		}
+		switch alg {
+		case "RS256", "ES256":
+			out = append(out, alg)
+		default:
+			return nil, fmt.Errorf("%s contains invalid value %q (allowed: RS256, ES256)", key, alg)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("%s must not be empty", key)
+	}
+	return out, nil
+}
+
+func validateJWKSURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("KEYCLOAK_JWKS_URL is invalid: %w", err)
+	}
+	if strings.TrimSpace(u.Scheme) == "" {
+		return fmt.Errorf("KEYCLOAK_JWKS_URL must include scheme")
+	}
+	if strings.TrimSpace(u.Host) == "" {
+		return fmt.Errorf("KEYCLOAK_JWKS_URL must include host")
+	}
+
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		host := strings.TrimSpace(strings.ToLower(u.Hostname()))
+		if host == "localhost" {
+			return nil
+		}
+		if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+			return nil
+		}
+		return fmt.Errorf("KEYCLOAK_JWKS_URL must use https unless host is localhost/loopback")
+	default:
+		return fmt.Errorf("KEYCLOAK_JWKS_URL must use http or https")
+	}
 }

--- a/cds_service/internal/config/config.go
+++ b/cds_service/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -91,6 +92,11 @@ func Load() (*Config, error) {
 	cfg.TrustedProxyCIDRs = parseListEnv("TRUSTED_PROXY_CIDRS")
 	if len(cfg.TrustedProxyCIDRs) == 0 {
 		return nil, fmt.Errorf("TRUSTED_PROXY_CIDRS is required")
+	}
+	for _, cidr := range cfg.TrustedProxyCIDRs {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return nil, fmt.Errorf("TRUSTED_PROXY_CIDRS contains invalid CIDR %q", cidr)
+		}
 	}
 	return cfg, nil
 }

--- a/cds_service/internal/config/config.go
+++ b/cds_service/internal/config/config.go
@@ -7,19 +7,38 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 )
 
 type Config struct {
-	PostgresDSN      string
-	HTTPAddr         string
-	ValidateTokenURL string
+	PostgresDSN string
+	HTTPAddr    string
+
+	AuthMode               string
+	KeycloakIssuerURL      string
+	KeycloakJWKSURL        string
+	KeycloakAudience       string
+	KeycloakRequiredRole   string
+	KeycloakAdminUIClient  string
+	DPoPRequired           bool
+	DPoPJtiCacheTTLSeconds int
+	DPoPProofMaxAgeSeconds int
+	DPoPClockSkewSeconds   int
+	JWKSCacheTTLSeconds    int
+	TrustedProxyCIDRs      []string
 }
 
 func Load() (*Config, error) {
 	cfg := &Config{
-		PostgresDSN:      os.Getenv("POSTGRES_DSN"),
-		HTTPAddr:         os.Getenv("HTTP_ADDR"),
-		ValidateTokenURL: os.Getenv("VALIDATE_TOKEN_URL"),
+		PostgresDSN:           os.Getenv("POSTGRES_DSN"),
+		HTTPAddr:              os.Getenv("HTTP_ADDR"),
+		AuthMode:              os.Getenv("AUTH_MODE"),
+		KeycloakIssuerURL:     os.Getenv("KEYCLOAK_ISSUER_URL"),
+		KeycloakJWKSURL:       os.Getenv("KEYCLOAK_JWKS_URL"),
+		KeycloakAudience:      os.Getenv("KEYCLOAK_AUDIENCE"),
+		KeycloakRequiredRole:  os.Getenv("KEYCLOAK_REQUIRED_ROLE"),
+		KeycloakAdminUIClient: os.Getenv("KEYCLOAK_ADMIN_UI_CLIENT_ID"),
 	}
 
 	if cfg.PostgresDSN == "" {
@@ -28,9 +47,93 @@ func Load() (*Config, error) {
 	if cfg.HTTPAddr == "" {
 		cfg.HTTPAddr = ":8080"
 	}
-	if cfg.ValidateTokenURL == "" {
-		return nil, fmt.Errorf("VALIDATE_TOKEN_URL is required")
+	if cfg.AuthMode == "" {
+		return nil, fmt.Errorf("AUTH_MODE is required")
+	}
+	if cfg.AuthMode != "keycloak-dpop" {
+		return nil, fmt.Errorf("AUTH_MODE must be keycloak-dpop")
+	}
+	if cfg.KeycloakIssuerURL == "" {
+		return nil, fmt.Errorf("KEYCLOAK_ISSUER_URL is required")
+	}
+	if cfg.KeycloakJWKSURL == "" {
+		return nil, fmt.Errorf("KEYCLOAK_JWKS_URL is required")
+	}
+	if cfg.KeycloakAudience == "" {
+		return nil, fmt.Errorf("KEYCLOAK_AUDIENCE is required")
+	}
+	if cfg.KeycloakRequiredRole == "" {
+		return nil, fmt.Errorf("KEYCLOAK_REQUIRED_ROLE is required")
+	}
+	if cfg.KeycloakAdminUIClient == "" {
+		return nil, fmt.Errorf("KEYCLOAK_ADMIN_UI_CLIENT_ID is required")
+	}
+
+	dpopRequired, err := parseBoolEnv("DPOP_REQUIRED", true)
+	if err != nil {
+		return nil, err
+	}
+	cfg.DPoPRequired = dpopRequired
+
+	if cfg.DPoPJtiCacheTTLSeconds, err = parseIntEnv("DPOP_JTI_CACHE_TTL_SECONDS", 300); err != nil {
+		return nil, err
+	}
+	if cfg.DPoPProofMaxAgeSeconds, err = parseIntEnv("DPOP_PROOF_MAX_AGE_SECONDS", 300); err != nil {
+		return nil, err
+	}
+	if cfg.DPoPClockSkewSeconds, err = parseIntEnv("DPOP_CLOCK_SKEW_SECONDS", 30); err != nil {
+		return nil, err
+	}
+	if cfg.JWKSCacheTTLSeconds, err = parseIntEnv("JWKS_CACHE_TTL_SECONDS", 300); err != nil {
+		return nil, err
+	}
+
+	cfg.TrustedProxyCIDRs = parseListEnv("TRUSTED_PROXY_CIDRS")
+	if len(cfg.TrustedProxyCIDRs) == 0 {
+		return nil, fmt.Errorf("TRUSTED_PROXY_CIDRS is required")
 	}
 	return cfg, nil
 }
 
+func parseIntEnv(key string, fallback int) (int, error) {
+	v := os.Getenv(key)
+	if strings.TrimSpace(v) == "" {
+		return fallback, nil
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be an integer", key)
+	}
+	if i <= 0 {
+		return 0, fmt.Errorf("%s must be > 0", key)
+	}
+	return i, nil
+}
+
+func parseBoolEnv(key string, fallback bool) (bool, error) {
+	v := os.Getenv(key)
+	if strings.TrimSpace(v) == "" {
+		return fallback, nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, fmt.Errorf("%s must be a boolean", key)
+	}
+	return b, nil
+}
+
+func parseListEnv(key string) []string {
+	raw := os.Getenv(key)
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/cds_service/internal/config/config_test.go
+++ b/cds_service/internal/config/config_test.go
@@ -17,6 +17,8 @@ func setRequiredAuthEnv(t *testing.T) {
 	t.Setenv("KEYCLOAK_AUDIENCE", "cds-service")
 	t.Setenv("KEYCLOAK_REQUIRED_ROLE", "cds-admin")
 	t.Setenv("KEYCLOAK_ADMIN_UI_CLIENT_ID", "cds-admin-ui")
+	t.Setenv("KEYCLOAK_ACCESS_TOKEN_ALG", "RS256")
+	t.Setenv("DPOP_ALLOWED_ALGS", "ES256")
 }
 
 func TestTrustedProxyCIDRsValidation(t *testing.T) {
@@ -59,4 +61,122 @@ func TestTrustedProxyCIDRsValidation(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestJWTAlgorithmConfigValidation(t *testing.T) {
+	t.Run("defaults are applied when envs are absent", func(t *testing.T) {
+		t.Setenv("AUTH_MODE", "keycloak-dpop")
+		t.Setenv("KEYCLOAK_ISSUER_URL", "http://127.0.0.1/test-realm")
+		t.Setenv("KEYCLOAK_JWKS_URL", "http://127.0.0.1/jwks")
+		t.Setenv("KEYCLOAK_AUDIENCE", "cds-service")
+		t.Setenv("KEYCLOAK_REQUIRED_ROLE", "cds-admin")
+		t.Setenv("KEYCLOAK_ADMIN_UI_CLIENT_ID", "cds-admin-ui")
+		t.Setenv("TRUSTED_PROXY_CIDRS", "127.0.0.1/32")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if cfg.KeycloakAccessTokenAlg != "RS256" {
+			t.Fatalf("got alg=%q", cfg.KeycloakAccessTokenAlg)
+		}
+		if len(cfg.DPoPAllowedAlgs) != 1 || cfg.DPoPAllowedAlgs[0] != "ES256" {
+			t.Fatalf("got DPoPAllowedAlgs=%v", cfg.DPoPAllowedAlgs)
+		}
+	})
+
+	t.Run("invalid KEYCLOAK_ACCESS_TOKEN_ALG rejected", func(t *testing.T) {
+		setRequiredAuthEnv(t)
+		t.Setenv("TRUSTED_PROXY_CIDRS", "127.0.0.1/32")
+		t.Setenv("KEYCLOAK_ACCESS_TOKEN_ALG", "HS256")
+		_, err := Load()
+		if err == nil || !strings.Contains(err.Error(), "KEYCLOAK_ACCESS_TOKEN_ALG") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty DPOP_ALLOWED_ALGS rejected", func(t *testing.T) {
+		setRequiredAuthEnv(t)
+		t.Setenv("TRUSTED_PROXY_CIDRS", "127.0.0.1/32")
+		t.Setenv("DPOP_ALLOWED_ALGS", "   ")
+		_, err := Load()
+		if err == nil || !strings.Contains(err.Error(), "DPOP_ALLOWED_ALGS must not be empty") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid DPOP_ALLOWED_ALGS entry rejected", func(t *testing.T) {
+		setRequiredAuthEnv(t)
+		t.Setenv("TRUSTED_PROXY_CIDRS", "127.0.0.1/32")
+		t.Setenv("DPOP_ALLOWED_ALGS", "ES256,HS256")
+		_, err := Load()
+		if err == nil || !strings.Contains(err.Error(), "DPOP_ALLOWED_ALGS contains invalid value") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestJWKSURLValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{
+			name:    "https URL allowed",
+			raw:     "https://keycloak.example.com/realms/cds/protocol/openid-connect/certs",
+			wantErr: false,
+		},
+		{
+			name:    "http localhost allowed",
+			raw:     "http://localhost:8080/jwks",
+			wantErr: false,
+		},
+		{
+			name:    "http 127.0.0.1 allowed",
+			raw:     "http://127.0.0.1:8080/jwks",
+			wantErr: false,
+		},
+		{
+			name:    "http ipv6 loopback allowed",
+			raw:     "http://[::1]:8080/jwks",
+			wantErr: false,
+		},
+		{
+			name:    "http non loopback rejected",
+			raw:     "http://keycloak.example.com/jwks",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported scheme rejected",
+			raw:     "ftp://keycloak.example.com/jwks",
+			wantErr: true,
+		},
+		{
+			name:    "missing scheme rejected",
+			raw:     "keycloak.example.com/jwks",
+			wantErr: true,
+		},
+		{
+			name:    "missing host rejected",
+			raw:     "https:///jwks",
+			wantErr: true,
+		},
+		{
+			name:    "malformed URL rejected",
+			raw:     "://bad",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateJWKSURL(tc.raw)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected success, got err=%v", err)
+			}
+		})
+	}
 }

--- a/cds_service/internal/config/config_test.go
+++ b/cds_service/internal/config/config_test.go
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ */
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func setRequiredAuthEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("AUTH_MODE", "keycloak-dpop")
+	t.Setenv("KEYCLOAK_ISSUER_URL", "http://127.0.0.1/test-realm")
+	t.Setenv("KEYCLOAK_JWKS_URL", "http://127.0.0.1/jwks")
+	t.Setenv("KEYCLOAK_AUDIENCE", "cds-service")
+	t.Setenv("KEYCLOAK_REQUIRED_ROLE", "cds-admin")
+	t.Setenv("KEYCLOAK_ADMIN_UI_CLIENT_ID", "cds-admin-ui")
+}
+
+func TestTrustedProxyCIDRsValidation(t *testing.T) {
+	t.Run("valid single CIDR accepted", func(t *testing.T) {
+		setRequiredAuthEnv(t)
+		t.Setenv("TRUSTED_PROXY_CIDRS", "127.0.0.1/32")
+		if _, err := Load(); err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+	})
+
+	t.Run("valid comma separated CIDRs with spaces accepted", func(t *testing.T) {
+		setRequiredAuthEnv(t)
+		t.Setenv("TRUSTED_PROXY_CIDRS", "127.0.0.1/32, ::1/128")
+		if _, err := Load(); err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+	})
+
+	t.Run("empty value rejected", func(t *testing.T) {
+		setRequiredAuthEnv(t)
+		t.Setenv("TRUSTED_PROXY_CIDRS", "   ")
+		_, err := Load()
+		if err == nil {
+			t.Fatalf("expected error for empty TRUSTED_PROXY_CIDRS")
+		}
+		if !strings.Contains(err.Error(), "TRUSTED_PROXY_CIDRS is required") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid CIDR rejected", func(t *testing.T) {
+		setRequiredAuthEnv(t)
+		t.Setenv("TRUSTED_PROXY_CIDRS", "127.0.0.1/32,not-a-cidr")
+		_, err := Load()
+		if err == nil {
+			t.Fatalf("expected error for invalid TRUSTED_PROXY_CIDRS")
+		}
+		if !strings.Contains(err.Error(), "invalid CIDR") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/cds_service/internal/http/access_log.go
+++ b/cds_service/internal/http/access_log.go
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ */
+package http
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"time"
+
+	"cds/internal/adapters/logger"
+)
+
+type accessCtxKey string
+
+const ctxKeyRequestID accessCtxKey = "requestID"
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	if !r.wroteHeader {
+		r.status = code
+		r.wroteHeader = true
+	}
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if !r.wroteHeader {
+		r.WriteHeader(http.StatusOK)
+	}
+	return r.ResponseWriter.Write(b)
+}
+
+func AccessLogger(next http.Handler) http.Handler {
+	log := logger.New()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		requestID := strings.TrimSpace(r.Header.Get("X-Request-Id"))
+		if requestID == "" {
+			requestID = generateRequestID()
+		}
+		w.Header().Set("X-Request-Id", requestID)
+
+		ctx := context.WithValue(r.Context(), ctxKeyRequestID, requestID)
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r.WithContext(ctx))
+
+		log.
+			WithField("method", r.Method).
+			WithField("path", r.URL.Path).
+			WithField("status", rec.status).
+			WithField("latency_ms", time.Since(start).Milliseconds()).
+			WithField("remote_addr", r.RemoteAddr).
+			WithField("request_id", requestID).
+			Infof("http_access")
+	})
+}
+
+func generateRequestID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "req-id-unavailable"
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func requestIDFromCtx(r *http.Request) string {
+	v := r.Context().Value(ctxKeyRequestID)
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}

--- a/cds_service/internal/http/api_integration_test.go
+++ b/cds_service/internal/http/api_integration_test.go
@@ -174,7 +174,7 @@ func jwkThumbprintRSA(pub *rsa.PublicKey) string {
 	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
-func buildAdminHeaders(method, path string, tokenSigner *keyMaterial, dpopKey *rsa.PrivateKey) map[string]string {
+func buildAdminHeadersForSubject(method, path string, tokenSigner *keyMaterial, dpopKey *rsa.PrivateKey, subject string) map[string]string {
 	now := time.Now().Unix()
 	nonce := make([]byte, 8)
 	if _, err := rand.Read(nonce); err != nil {
@@ -188,7 +188,7 @@ func buildAdminHeaders(method, path string, tokenSigner *keyMaterial, dpopKey *r
 		"kid": tokenSigner.kid,
 	}, map[string]any{
 		"iss": "https://keycloak.example.com/realms/cds",
-		"sub": "admin-subject-1",
+		"sub": subject,
 		"aud": []string{"cds-service"},
 		"exp": now + 3600,
 		"iat": now,
@@ -224,6 +224,10 @@ func buildAdminHeaders(method, path string, tokenSigner *keyMaterial, dpopKey *r
 		"Content-Type":  "application/json",
 		"Accept":        "application/json",
 	}
+}
+
+func buildAdminHeaders(method, path string, tokenSigner *keyMaterial, dpopKey *rsa.PrivateKey) map[string]string {
+	return buildAdminHeadersForSubject(method, path, tokenSigner, dpopKey, "admin-subject-1")
 }
 
 func TestCRUDAndDeviceFacingAPIIntegration(t *testing.T) {
@@ -283,5 +287,43 @@ func TestCRUDAndDeviceFacingAPIIntegration(t *testing.T) {
 	}
 	if len(listed) != 0 {
 		t.Fatalf("expected empty list after delete, got %#v", listed)
+	}
+}
+
+func TestPostOwnershipConflictPreventsTakeover(t *testing.T) {
+	router, db, signer, dpopKey := newIntegrationRouter(t)
+	adminA := "admin-subject-a"
+	adminB := "admin-subject-b"
+
+	postA1 := `{"serial":"B4:6A:D4:45:F0:19","controller_endpoint":"openwifi-a.routerarchitects.com"}`
+	rr := performJSONRequest(router, http.MethodPost, "/v1/device", postA1, buildAdminHeadersForSubject(http.MethodPost, "/v1/device", signer, dpopKey, adminA))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("admin A first POST got %d, want %d (body=%s)", rr.Code, http.StatusCreated, rr.Body.String())
+	}
+
+	postA2 := `{"serial":"B4:6A:D4:45:F0:19","controller_endpoint":"openwifi-a2.routerarchitects.com"}`
+	rr = performJSONRequest(router, http.MethodPost, "/v1/device", postA2, buildAdminHeadersForSubject(http.MethodPost, "/v1/device", signer, dpopKey, adminA))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("admin A second POST got %d, want %d (body=%s)", rr.Code, http.StatusCreated, rr.Body.String())
+	}
+
+	postB := `{"serial":"B4:6A:D4:45:F0:19","controller_endpoint":"openwifi-b.routerarchitects.com"}`
+	rr = performJSONRequest(router, http.MethodPost, "/v1/device", postB, buildAdminHeadersForSubject(http.MethodPost, "/v1/device", signer, dpopKey, adminB))
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("admin B POST got %d, want %d (body=%s)", rr.Code, http.StatusConflict, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "device already exists for another owner") {
+		t.Fatalf("admin B POST body=%q", rr.Body.String())
+	}
+
+	var ownerScope, endpoint string
+	if err := db.QueryRow(`SELECT owner_scope, controller_endpoint FROM public.devices WHERE serial=$1`, testSerial).Scan(&ownerScope, &endpoint); err != nil {
+		t.Fatalf("query device row: %v", err)
+	}
+	if ownerScope != adminA {
+		t.Fatalf("owner_scope changed: got=%q want=%q", ownerScope, adminA)
+	}
+	if endpoint != "openwifi-a2.routerarchitects.com" {
+		t.Fatalf("controller_endpoint changed by admin B: got=%q", endpoint)
 	}
 }

--- a/cds_service/internal/http/api_integration_test.go
+++ b/cds_service/internal/http/api_integration_test.go
@@ -140,7 +140,7 @@ func newIntegrationRouter(t *testing.T) (http.Handler, *sql.DB, *keyMaterial, *r
 		DPoPProofMaxAgeSeconds: 300,
 		DPoPClockSkewSeconds:   30,
 		JWKSCacheTTLSeconds:    300,
-		TrustedProxyCIDRs:      []string{"10.0.0.0/8"},
+		TrustedProxyCIDRs:      []string{"10.0.0.0/8", "127.0.0.1/32"},
 	}
 	t.Cleanup(jwks.Close)
 	t.Cleanup(func() { _ = db.Close() })
@@ -251,10 +251,12 @@ func TestCRUDAndDeviceFacingAPIIntegration(t *testing.T) {
 		t.Fatalf("unexpected list response: %#v", listed)
 	}
 
-	rr = performJSONRequest(router, http.MethodGet, "/v1/devices/B4:6A:D4:45:F0:19", "", map[string]string{
-		"X-SSL-Client-Verify": "SUCCESS",
-		"Accept":              "application/json",
-	})
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/B4:6A:D4:45:F0:19", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("X-SSL-Client-Verify", "SUCCESS")
+	req.Header.Set("Accept", "application/json")
+	rr = httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("GET /v1/devices/{serial} got %d, want %d (body=%s)", rr.Code, http.StatusOK, rr.Body.String())
 	}

--- a/cds_service/internal/http/api_integration_test.go
+++ b/cds_service/internal/http/api_integration_test.go
@@ -8,9 +8,15 @@ import (
 	"cds/internal/adapters/postgres"
 	"cds/internal/config"
 	"cds/internal/services"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -18,19 +24,18 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	_ "github.com/lib/pq"
 )
 
 const (
-	testOwnerToken = "root-token"
-	testSerial     = "b4:6a:d4:45:f0:19"
-	testEndpoint   = "openwifi3.routerarchitects.com"
+	testSerial   = "b4:6a:d4:45:f0:19"
+	testEndpoint = "openwifi3.routerarchitects.com"
 )
 
 func mustOpenTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-
 	dsn := os.Getenv("POSTGRES_DSN")
 	if dsn == "" {
 		t.Skip("POSTGRES_DSN not set; skipping integration tests")
@@ -38,7 +43,6 @@ func mustOpenTestDB(t *testing.T) *sql.DB {
 	if err := requireSafeTestDB(dsn); err != nil {
 		t.Fatalf("unsafe POSTGRES_DSN for integration test: %v", err)
 	}
-
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		t.Fatalf("open postgres: %v", err)
@@ -64,14 +68,13 @@ func requireSafeTestDB(dsn string) error {
 
 func resetDevicesTable(t *testing.T, db *sql.DB) {
 	t.Helper()
-
 	const schema = `
 CREATE TABLE IF NOT EXISTS public.devices (
   serial TEXT PRIMARY KEY,
   controller_endpoint TEXT NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-  owner_token TEXT
+  owner_scope TEXT
 );
 TRUNCATE TABLE public.devices;
 `
@@ -80,42 +83,72 @@ TRUNCATE TABLE public.devices;
 	}
 }
 
-func newRootValidator(t *testing.T) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		token := r.URL.Query().Get("token")
-		if token == "" || r.Header.Get("Authorization") != "Bearer "+token {
-			http.Error(w, "invalid token header", http.StatusForbidden)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"tokenInfo": map[string]string{"access_token": token},
-			"userInfo":  map[string]string{"userRole": "root"},
-		})
-	}))
+type keyMaterial struct {
+	key *rsa.PrivateKey
+	kid string
 }
 
-func newIntegrationRouter(t *testing.T) (*http.ServeMux, *sql.DB) {
-	t.Helper()
+func newJWKSHandler(km *keyMaterial) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pub := km.key.Public().(*rsa.PublicKey)
+		jwks := map[string]any{
+			"keys": []map[string]any{
+				{
+					"kty": "RSA",
+					"kid": km.kid,
+					"use": "sig",
+					"alg": "RS256",
+					"n":   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+					"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	})
+}
 
+func newIntegrationRouter(t *testing.T) (http.Handler, *sql.DB, *keyMaterial, *rsa.PrivateKey) {
+	t.Helper()
 	db := mustOpenTestDB(t)
 	resetDevicesTable(t, db)
 
+	tokenKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate token key: %v", err)
+	}
+	dpopKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate dpop key: %v", err)
+	}
+	km := &keyMaterial{key: tokenKey, kid: "test-kid-1"}
+	jwks := httptest.NewServer(newJWKSHandler(km))
+
 	repo := postgres.NewRepo(db)
 	svc := services.New(repo)
-	validator := newRootValidator(t)
-	t.Cleanup(validator.Close)
-	t.Cleanup(func() { _ = db.Close() })
-
 	cfg := &config.Config{
-		ValidateTokenURL: validator.URL,
+		PostgresDSN:            "postgres://unused",
+		HTTPAddr:               ":8080",
+		AuthMode:               "keycloak-dpop",
+		KeycloakIssuerURL:      "https://keycloak.example.com/realms/cds",
+		KeycloakJWKSURL:        jwks.URL,
+		KeycloakAudience:       "cds-service",
+		KeycloakRequiredRole:   "cds-admin",
+		KeycloakAdminUIClient:  "cds-admin-ui",
+		DPoPRequired:           true,
+		DPoPJtiCacheTTLSeconds: 300,
+		DPoPProofMaxAgeSeconds: 300,
+		DPoPClockSkewSeconds:   30,
+		JWKSCacheTTLSeconds:    300,
+		TrustedProxyCIDRs:      []string{"10.0.0.0/8"},
 	}
-	return NewRouterWithConfig(cfg, svc), db
+	t.Cleanup(jwks.Close)
+	t.Cleanup(func() { _ = db.Close() })
+	return NewRouterWithConfig(cfg, svc), db, km, dpopKey
 }
 
-func performJSONRequest(router http.Handler, method, path, body string, headers map[string]string) *httptest.ResponseRecorder {
-	req := httptest.NewRequest(method, path, strings.NewReader(body))
+func performJSONRequest(router http.Handler, method, p, body string, headers map[string]string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, p, strings.NewReader(body))
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
@@ -124,24 +157,85 @@ func performJSONRequest(router http.Handler, method, path, body string, headers 
 	return rr
 }
 
-func adminHeaders() map[string]string {
+func signJWT(privateKey *rsa.PrivateKey, header map[string]any, payload map[string]any) string {
+	hb, _ := json.Marshal(header)
+	pb, _ := json.Marshal(payload)
+	unsigned := base64.RawURLEncoding.EncodeToString(hb) + "." + base64.RawURLEncoding.EncodeToString(pb)
+	h := sha256.Sum256([]byte(unsigned))
+	sig, _ := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, h[:])
+	return unsigned + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func jwkThumbprintRSA(pub *rsa.PublicKey) string {
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	canonical := `{"e":"` + e + `","kty":"RSA","n":"` + n + `"}`
+	sum := sha256.Sum256([]byte(canonical))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func buildAdminHeaders(method, path string, tokenSigner *keyMaterial, dpopKey *rsa.PrivateKey) map[string]string {
+	now := time.Now().Unix()
+	nonce := make([]byte, 8)
+	if _, err := rand.Read(nonce); err != nil {
+		panic(err)
+	}
+	dpopPub := dpopKey.Public().(*rsa.PublicKey)
+	dpopJKT := jwkThumbprintRSA(dpopPub)
+	accessToken := signJWT(tokenSigner.key, map[string]any{
+		"alg": "RS256",
+		"typ": "JWT",
+		"kid": tokenSigner.kid,
+	}, map[string]any{
+		"iss": "https://keycloak.example.com/realms/cds",
+		"sub": "admin-subject-1",
+		"aud": []string{"cds-service"},
+		"exp": now + 3600,
+		"iat": now,
+		"azp": "cds-admin-ui",
+		"cnf": map[string]any{"jkt": dpopJKT},
+		"resource_access": map[string]any{
+			"cds-service": map[string]any{
+				"roles": []string{"cds-admin"},
+			},
+		},
+	})
+
+	athHash := sha256.Sum256([]byte(accessToken))
+	ath := base64.RawURLEncoding.EncodeToString(athHash[:])
+	dpopProof := signJWT(dpopKey, map[string]any{
+		"alg": "RS256",
+		"typ": "dpop+jwt",
+		"jwk": map[string]any{
+			"kty": "RSA",
+			"n":   base64.RawURLEncoding.EncodeToString(dpopPub.N.Bytes()),
+			"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(dpopPub.E)).Bytes()),
+		},
+	}, map[string]any{
+		"htu": "http://example.com" + path,
+		"htm": method,
+		"iat": now,
+		"jti": fmt.Sprintf("jti-%d-%s-%s-%s", now, method, path, base64.RawURLEncoding.EncodeToString(nonce)),
+		"ath": ath,
+	})
 	return map[string]string{
-		"X-Auth-Token": testOwnerToken,
-		"Content-Type": "application/json",
-		"Accept":       "application/json",
+		"Authorization": "DPoP " + accessToken,
+		"DPoP":          dpopProof,
+		"Content-Type":  "application/json",
+		"Accept":        "application/json",
 	}
 }
 
 func TestCRUDAndDeviceFacingAPIIntegration(t *testing.T) {
-	router, _ := newIntegrationRouter(t)
+	router, _, signer, dpopKey := newIntegrationRouter(t)
 
 	postBody := `{"serial":"B4:6A:D4:45:F0:19","controller_endpoint":"` + testEndpoint + `"}`
-	rr := performJSONRequest(router, http.MethodPost, "/v1/device", postBody, adminHeaders())
+	rr := performJSONRequest(router, http.MethodPost, "/v1/device", postBody, buildAdminHeaders(http.MethodPost, "/v1/device", signer, dpopKey))
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("POST /v1/device got %d, want %d (body=%s)", rr.Code, http.StatusCreated, rr.Body.String())
 	}
 
-	rr = performJSONRequest(router, http.MethodGet, "/v1/device", "", adminHeaders())
+	rr = performJSONRequest(router, http.MethodGet, "/v1/device", "", buildAdminHeaders(http.MethodGet, "/v1/device", signer, dpopKey))
 	if rr.Code != http.StatusOK {
 		t.Fatalf("GET /v1/device got %d, want %d (body=%s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -169,32 +263,17 @@ func TestCRUDAndDeviceFacingAPIIntegration(t *testing.T) {
 	}
 
 	putBody := `{"serial":"B4:6A:D4:45:F0:19","controller_endpoint":"openwifi9.routerarchitects.com"}`
-	rr = performJSONRequest(router, http.MethodPut, "/v1/device", putBody, adminHeaders())
+	rr = performJSONRequest(router, http.MethodPut, "/v1/device", putBody, buildAdminHeaders(http.MethodPut, "/v1/device", signer, dpopKey))
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("PUT /v1/device got %d, want %d (body=%s)", rr.Code, http.StatusNoContent, rr.Body.String())
 	}
 
-	rr = performJSONRequest(router, http.MethodGet, "/v1/devices/B4:6A:D4:45:F0:19", "", map[string]string{
-		"X-SSL-Client-Verify": "SUCCESS",
-		"Accept":              "application/json",
-	})
-	if rr.Code != http.StatusOK {
-		t.Fatalf("GET /v1/devices/{serial} after update got %d, want %d (body=%s)", rr.Code, http.StatusOK, rr.Body.String())
-	}
-	device = nil
-	if err := json.NewDecoder(rr.Body).Decode(&device); err != nil {
-		t.Fatalf("decode device response after update: %v", err)
-	}
-	if device["serial"] != testSerial || device["controller_endpoint"] != "openwifi9.routerarchitects.com" {
-		t.Fatalf("unexpected device response after update: %#v", device)
-	}
-
-	rr = performJSONRequest(router, http.MethodDelete, "/v1/device", `{"serial":"B4:6A:D4:45:F0:19"}`, adminHeaders())
+	rr = performJSONRequest(router, http.MethodDelete, "/v1/device/B4:6A:D4:45:F0:19", "", buildAdminHeaders(http.MethodDelete, "/v1/device/B4:6A:D4:45:F0:19", signer, dpopKey))
 	if rr.Code != http.StatusNoContent {
-		t.Fatalf("DELETE /v1/device got %d, want %d (body=%s)", rr.Code, http.StatusNoContent, rr.Body.String())
+		t.Fatalf("DELETE /v1/device/{serial} got %d, want %d (body=%s)", rr.Code, http.StatusNoContent, rr.Body.String())
 	}
 
-	rr = performJSONRequest(router, http.MethodGet, "/v1/device", "", adminHeaders())
+	rr = performJSONRequest(router, http.MethodGet, "/v1/device", "", buildAdminHeaders(http.MethodGet, "/v1/device", signer, dpopKey))
 	if rr.Code != http.StatusOK {
 		t.Fatalf("GET /v1/device (after delete) got %d, want %d (body=%s)", rr.Code, http.StatusOK, rr.Body.String())
 	}

--- a/cds_service/internal/http/api_integration_test.go
+++ b/cds_service/internal/http/api_integration_test.go
@@ -142,7 +142,7 @@ func newIntegrationRouter(t *testing.T) (http.Handler, *sql.DB, *keyMaterial, *r
 		DPoPProofMaxAgeSeconds: 300,
 		DPoPClockSkewSeconds:   30,
 		JWKSCacheTTLSeconds:    300,
-		TrustedProxyCIDRs:      []string{"10.0.0.0/8", "127.0.0.1/32"},
+		TrustedProxyCIDRs:      []string{"127.0.0.1/32"},
 	}
 	t.Cleanup(jwks.Close)
 	t.Cleanup(func() { _ = db.Close() })

--- a/cds_service/internal/http/api_integration_test.go
+++ b/cds_service/internal/http/api_integration_test.go
@@ -135,6 +135,8 @@ func newIntegrationRouter(t *testing.T) (http.Handler, *sql.DB, *keyMaterial, *r
 		KeycloakAudience:       "cds-service",
 		KeycloakRequiredRole:   "cds-admin",
 		KeycloakAdminUIClient:  "cds-admin-ui",
+		KeycloakAccessTokenAlg: "RS256",
+		DPoPAllowedAlgs:        []string{"ES256", "RS256"},
 		DPoPRequired:           true,
 		DPoPJtiCacheTTLSeconds: 300,
 		DPoPProofMaxAgeSeconds: 300,

--- a/cds_service/internal/http/handlers_devices.go
+++ b/cds_service/internal/http/handlers_devices.go
@@ -6,9 +6,11 @@ package http
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
+	"cds/internal/adapters/postgres"
 	"cds/internal/services"
 )
 
@@ -72,7 +74,11 @@ func (h *DeviceHandler) Add(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.svc.AddOwned(req.Serial, req.ControllerEndpoint, ownerScope); err != nil {
-		http.Error(w, err.Error(), http.StatusConflict)
+		if errors.Is(err, postgres.ErrDeviceOwnerConflict) {
+			http.Error(w, "device already exists for another owner", http.StatusConflict)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)

--- a/cds_service/internal/http/handlers_devices.go
+++ b/cds_service/internal/http/handlers_devices.go
@@ -41,7 +41,7 @@ func (h *DeviceHandler) LookupBySerial(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// -------------- Admin (validated token, userRole=root) ----------------
+// -------------- Admin (Keycloak DPoP) ----------------
 
 type addReq struct {
 	Serial             string `json:"serial"`
@@ -50,9 +50,6 @@ type addReq struct {
 type updateReq struct {
 	Serial             string `json:"serial"`
 	ControllerEndpoint string `json:"controller_endpoint"`
-}
-type deleteReq struct {
-	Serial string `json:"serial"`
 }
 
 // POST /v1/device
@@ -64,9 +61,9 @@ func (h *DeviceHandler) Add(w http.ResponseWriter, r *http.Request) {
 	}
 	req.Serial = strings.ToLower(strings.TrimSpace(req.Serial))
 
-	ownerToken, err := GetOwnerTokenFromCtx(r)
+	ownerScope, err := GetOwnerScopeFromCtx(r)
 	if err != nil {
-		http.Error(w, "security token validation failed", http.StatusForbidden)
+		http.Error(w, "invalid access token", http.StatusUnauthorized)
 		return
 	}
 	if req.Serial == "" || strings.TrimSpace(req.ControllerEndpoint) == "" {
@@ -74,7 +71,7 @@ func (h *DeviceHandler) Add(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.svc.AddOwned(req.Serial, req.ControllerEndpoint, ownerToken); err != nil {
+	if err := h.svc.AddOwned(req.Serial, req.ControllerEndpoint, ownerScope); err != nil {
 		http.Error(w, err.Error(), http.StatusConflict)
 		return
 	}
@@ -91,9 +88,9 @@ func (h *DeviceHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	req.Serial = strings.ToLower(strings.TrimSpace(req.Serial))
 
-	ownerToken, err := GetOwnerTokenFromCtx(r)
+	ownerScope, err := GetOwnerScopeFromCtx(r)
 	if err != nil {
-		http.Error(w, "security token validation failed", http.StatusForbidden)
+		http.Error(w, "invalid access token", http.StatusUnauthorized)
 		return
 	}
 	if req.Serial == "" || strings.TrimSpace(req.ControllerEndpoint) == "" {
@@ -101,33 +98,28 @@ func (h *DeviceHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.svc.UpdateOwned(req.Serial, req.ControllerEndpoint, ownerToken); err != nil {
+	if err := h.svc.UpdateOwned(req.Serial, req.ControllerEndpoint, ownerScope); err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// DELETE /v1/device
+// DELETE /v1/device/{serial}
 func (h *DeviceHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	var req deleteReq
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
-		return
-	}
-	req.Serial = strings.ToLower(strings.TrimSpace(req.Serial))
+	serial := strings.ToLower(strings.TrimSpace(r.PathValue("serial")))
 
-	ownerToken, err := GetOwnerTokenFromCtx(r)
+	ownerScope, err := GetOwnerScopeFromCtx(r)
 	if err != nil {
-		http.Error(w, "security token validation failed", http.StatusForbidden)
+		http.Error(w, "invalid access token", http.StatusUnauthorized)
 		return
 	}
-	if req.Serial == "" {
-		http.Error(w, "serial is required", http.StatusBadRequest)
+	if serial == "" {
+		http.Error(w, "serial path parameter is empty or whitespace after trimming", http.StatusBadRequest)
 		return
 	}
 
-	if err := h.svc.DeleteOwned(req.Serial, ownerToken); err != nil {
+	if err := h.svc.DeleteOwned(serial, ownerScope); err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
@@ -136,12 +128,12 @@ func (h *DeviceHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 // GET /v1/device
 func (h *DeviceHandler) List(w http.ResponseWriter, r *http.Request) {
-	ownerToken, err := GetOwnerTokenFromCtx(r)
+	ownerScope, err := GetOwnerScopeFromCtx(r)
 	if err != nil {
-		http.Error(w, "security token validation failed", http.StatusForbidden)
+		http.Error(w, "invalid access token", http.StatusUnauthorized)
 		return
 	}
-	devices, err := h.svc.ListByOwner(ownerToken)
+	devices, err := h.svc.ListByOwner(ownerScope)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/cds_service/internal/http/handlers_devices.go
+++ b/cds_service/internal/http/handlers_devices.go
@@ -54,10 +54,18 @@ type updateReq struct {
 	ControllerEndpoint string `json:"controller_endpoint"`
 }
 
+const maxAdminRequestBodyBytes int64 = 1 << 20 // 1 MiB
+
 // POST /v1/device
 func (h *DeviceHandler) Add(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxAdminRequestBodyBytes)
 	var req addReq
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
@@ -87,8 +95,14 @@ func (h *DeviceHandler) Add(w http.ResponseWriter, r *http.Request) {
 
 // PUT /v1/device
 func (h *DeviceHandler) Update(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxAdminRequestBodyBytes)
 	var req updateReq
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}

--- a/cds_service/internal/http/middleware.go
+++ b/cds_service/internal/http/middleware.go
@@ -74,8 +74,10 @@ func RequireKeycloakDPoPAdmin(cfg *config.Config, next http.Handler) http.Handle
 		kid := extractJWTKid(accessToken)
 
 		tokenClaims, kidKnown, err := actx.validateAccessToken(accessToken)
-		if err != nil && errors.Is(err, errUnknownKID) && !kidKnown {
-			logAdminAuth(log, "unknown_kid_detected", r, kid, nil)
+		if err != nil && ((errors.Is(err, errUnknownKID) && !kidKnown) || errors.Is(err, errJWKSCacheStale)) {
+			if errors.Is(err, errUnknownKID) && !kidKnown {
+				logAdminAuth(log, "unknown_kid_detected", r, kid, nil)
+			}
 			logAdminAuth(log, "jwks_refresh_started", r, kid, nil)
 			if refreshErr := actx.jwks.refresh(r.Context(), actx.client, cfg.KeycloakJWKSURL); refreshErr != nil {
 				logAdminAuth(log, "jwks_fetch_failed", r, kid, nil)
@@ -175,6 +177,7 @@ func getAuthContext(cfg *config.Config) *authContext {
 
 var (
 	errUnknownKID          = errors.New("unknown access token kid after JWKS refresh")
+	errJWKSCacheStale      = errors.New("jwks cache stale")
 	errInvalidConfig       = errors.New("server Keycloak configuration invalid")
 	errInvalidAdminClient  = errors.New("invalid admin client")
 	errMissingRequiredRole = errors.New("missing required role")
@@ -224,7 +227,10 @@ func (a *authContext) validateAccessToken(token string) (*tokenClaims, bool, err
 		return nil, false, errJWTInvalid
 	}
 
-	key, found := a.jwks.get(kid)
+	key, found, stale := a.jwks.get(kid)
+	if stale {
+		return nil, found, errJWKSCacheStale
+	}
 	if !found {
 		return nil, false, errUnknownKID
 	}
@@ -423,15 +429,15 @@ func newJWKSCache(ttl time.Duration) *jwksCache {
 	return &jwksCache{keys: map[string]any{}, ttl: ttl}
 }
 
-func (j *jwksCache) get(kid string) (any, bool) {
+func (j *jwksCache) get(kid string) (any, bool, bool) {
 	j.mu.RLock()
 	key, ok := j.keys[kid]
 	stale := j.lastSyncAt.IsZero() || time.Since(j.lastSyncAt) > j.ttl
 	j.mu.RUnlock()
 	if ok || !stale {
-		return key, ok
+		return key, ok, stale
 	}
-	return nil, false
+	return nil, false, true
 }
 
 func (j *jwksCache) refresh(ctx context.Context, client *http.Client, jwksURL string) error {

--- a/cds_service/internal/http/middleware.go
+++ b/cds_service/internal/http/middleware.go
@@ -231,6 +231,10 @@ func (a *authContext) validateAccessToken(token string) (*tokenClaims, bool, err
 	if kid == "" {
 		return nil, false, errJWTInvalid
 	}
+	alg, _ := header["alg"].(string)
+	if alg != a.cfg.KeycloakAccessTokenAlg {
+		return nil, false, errJWTInvalid
+	}
 
 	key, found, stale := a.jwks.get(kid)
 	if stale {
@@ -307,6 +311,10 @@ func (a *authContext) validateTokenClaims(c *tokenClaims) error {
 func (a *authContext) validateDPoPProof(r *http.Request, proof, accessToken, expectedJKT string) error {
 	header, payload, sig, input, err := parseJWT(proof)
 	if err != nil {
+		return errDPoPInvalid
+	}
+	alg, _ := header["alg"].(string)
+	if !contains(a.cfg.DPoPAllowedAlgs, alg) {
 		return errDPoPInvalid
 	}
 	jwkVal, ok := header["jwk"]

--- a/cds_service/internal/http/middleware.go
+++ b/cds_service/internal/http/middleware.go
@@ -6,27 +6,30 @@ package http
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math/big"
+	"net"
 	"net/http"
 	"net/url"
+	"strings"
+	"sync"
 	"time"
 
+	"cds/internal/adapters/logger"
 	"cds/internal/config"
 )
 
 type ctxKey string
 
-const ctxKeyOwnerToken ctxKey = "ownerToken"
-
-type tokenValidationResponse struct {
-	TokenInfo struct {
-		AccessToken string `json:"access_token"`
-	} `json:"tokenInfo"`
-	UserInfo struct {
-		UserRole string `json:"userRole"`
-	} `json:"userInfo"`
-}
+const ctxKeyOwnerScope ctxKey = "ownerScope"
 
 // Device mTLS guard (existing behavior)
 func RequireClientCert(next http.Handler) http.Handler {
@@ -39,73 +42,700 @@ func RequireClientCert(next http.Handler) http.Handler {
 	})
 }
 
-// New admin validator middleware:
-// - reads X-Auth-Token
-// - calls VALIDATE_TOKEN_URL with ?token=... and Authorization: Bearer ...
-// - requires userRole == "root"
-// - injects token into ctx
-func RequireValidatedAdmin(cfg *config.Config, next http.Handler) http.Handler {
-	client := &http.Client{Timeout: 10 * time.Second}
+type authContext struct {
+	cfg          *config.Config
+	client       *http.Client
+	jwks         *jwksCache
+	replay       *jtiReplayCache
+	trustedCIDRs []*net.IPNet
+}
 
+var (
+	authCtxMu sync.Mutex
+	authCtxBy = map[*config.Config]*authContext{}
+)
+
+func RequireKeycloakDPoPAdmin(cfg *config.Config, next http.Handler) http.Handler {
+	actx := getAuthContext(cfg)
+	log := logger.New()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		token := r.Header.Get("X-Auth-Token")
-		if token == "" {
-			http.Error(w, "missing X-Auth-Token", http.StatusForbidden)
-			return
-		}
-
-		u, err := url.Parse(cfg.ValidateTokenURL)
+		accessToken, err := parseAuthorizationDPoP(r.Header.Get("Authorization"))
 		if err != nil {
-			http.Error(w, "server validator URL invalid", http.StatusInternalServerError)
+			reason := "jwt_invalid"
+			if errors.Is(err, errJWTMissing) {
+				reason = "jwt_missing"
+			} else if errors.Is(err, errJWTSchemeInvalid) {
+				reason = "jwt_scheme_invalid"
+			}
+			logAdminAuth(log, reason, r, "", nil)
+			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
-		q := u.Query()
-		q.Set("token", token)
-		u.RawQuery = q.Encode()
+		kid := extractJWTKid(accessToken)
 
-		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, u.String(), nil)
+		tokenClaims, kidKnown, err := actx.validateAccessToken(accessToken)
+		if err != nil && errors.Is(err, errUnknownKID) && !kidKnown {
+			logAdminAuth(log, "unknown_kid_detected", r, kid, nil)
+			logAdminAuth(log, "jwks_refresh_started", r, kid, nil)
+			if refreshErr := actx.jwks.refresh(r.Context(), actx.client, cfg.KeycloakJWKSURL); refreshErr != nil {
+				logAdminAuth(log, "jwks_fetch_failed", r, kid, nil)
+				http.Error(w, "failed to fetch Keycloak JWKS", http.StatusInternalServerError)
+				return
+			}
+			logAdminAuth(log, "jwks_refresh_succeeded", r, kid, nil)
+			tokenClaims, _, err = actx.validateAccessToken(accessToken)
+			if err == nil {
+				logAdminAuth(log, "retry_succeeded", r, kid, nil)
+			}
+		}
 		if err != nil {
-			http.Error(w, "failed to build validation request", http.StatusInternalServerError)
-			return
-		}
-		req.Header.Set("Accept", "application/json")
-		req.Header.Set("Authorization", "Bearer "+token)
-
-		resp, err := client.Do(req)
-		if err != nil {
-			http.Error(w, "security token validation failed", http.StatusForbidden)
-			return
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			http.Error(w, "security token validation failed", http.StatusForbidden)
-			return
-		}
-
-		var tv tokenValidationResponse
-		if err := json.NewDecoder(resp.Body).Decode(&tv); err != nil {
-			http.Error(w, "invalid validation response", http.StatusForbidden)
-			return
-		}
-		if tv.UserInfo.UserRole != "root" {
-			http.Error(w, "error:Only root user is allowed.", http.StatusForbidden)
+			if errors.Is(err, errUnknownKID) {
+				logAdminAuth(log, "unknown_kid_refresh_failed", r, kid, nil)
+				http.Error(w, "unknown access token kid after JWKS refresh", http.StatusUnauthorized)
+				return
+			}
+			if errors.Is(err, errInvalidAdminClient) || errors.Is(err, errMissingRequiredRole) {
+				logAdminAuth(log, "role_missing", r, kid, nil)
+				http.Error(w, err.Error(), http.StatusForbidden)
+				return
+			}
+			logAdminAuth(log, "jwt_invalid", r, kid, nil)
+			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
 
-		ctx := context.WithValue(r.Context(), ctxKeyOwnerToken, token)
+		if cfg.DPoPRequired {
+			dpopProof := r.Header.Get("DPoP")
+			if strings.TrimSpace(dpopProof) == "" {
+				logAdminAuth(log, "dpop_missing", r, kid, nil)
+				http.Error(w, "missing DPoP proof", http.StatusUnauthorized)
+				return
+			}
+			if err := actx.validateDPoPProof(r, dpopProof, accessToken, tokenClaims.CnfJKT); err != nil {
+				status := http.StatusUnauthorized
+				if errors.Is(err, errInvalidConfig) {
+					status = http.StatusInternalServerError
+				}
+				reason := "dpop_invalid"
+				var trusted *bool
+				if errors.Is(err, errDPoPHTUMismatch) {
+					reason = "dpop_htu_mismatch"
+					v := actx.isTrustedRemote(r.RemoteAddr)
+					trusted = &v
+				} else if errors.Is(err, errDPoPReplay) {
+					reason = "dpop_replay"
+				} else if errors.Is(err, errDPoPJKTMismatch) {
+					reason = "dpop_jkt_mismatch"
+				}
+				logAdminAuth(log, reason, r, kid, trusted)
+				http.Error(w, err.Error(), status)
+				return
+			}
+		}
+
+		ctx := context.WithValue(r.Context(), ctxKeyOwnerScope, tokenClaims.Subject)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
-// Extract validated owner token from ctx
-func GetOwnerTokenFromCtx(r *http.Request) (string, error) {
-	v := r.Context().Value(ctxKeyOwnerToken)
+func GetOwnerScopeFromCtx(r *http.Request) (string, error) {
+	v := r.Context().Value(ctxKeyOwnerScope)
 	if v == nil {
-		return "", fmt.Errorf("owner token missing from context")
+		return "", fmt.Errorf("owner scope missing from context")
 	}
 	if s, ok := v.(string); ok && s != "" {
 		return s, nil
 	}
-	return "", fmt.Errorf("owner token missing from context")
+	return "", fmt.Errorf("owner scope missing from context")
 }
 
+func getAuthContext(cfg *config.Config) *authContext {
+	authCtxMu.Lock()
+	defer authCtxMu.Unlock()
+	if v, ok := authCtxBy[cfg]; ok {
+		return v
+	}
+	cidrs := make([]*net.IPNet, 0, len(cfg.TrustedProxyCIDRs))
+	for _, c := range cfg.TrustedProxyCIDRs {
+		_, ipn, err := net.ParseCIDR(c)
+		if err == nil {
+			cidrs = append(cidrs, ipn)
+		}
+	}
+	v := &authContext{
+		cfg:          cfg,
+		client:       &http.Client{Timeout: 10 * time.Second},
+		jwks:         newJWKSCache(time.Duration(cfg.JWKSCacheTTLSeconds) * time.Second),
+		replay:       newJTIReplayCache(time.Duration(cfg.DPoPJtiCacheTTLSeconds) * time.Second),
+		trustedCIDRs: cidrs,
+	}
+	authCtxBy[cfg] = v
+	return v
+}
+
+var (
+	errUnknownKID          = errors.New("unknown access token kid after JWKS refresh")
+	errInvalidConfig       = errors.New("server Keycloak configuration invalid")
+	errInvalidAdminClient  = errors.New("invalid admin client")
+	errMissingRequiredRole = errors.New("missing required role")
+	errJWTMissing          = errors.New("missing Authorization header")
+	errJWTSchemeInvalid    = errors.New("Authorization scheme must be DPoP")
+	errJWTInvalid          = errors.New("invalid access token")
+	errDPoPInvalid         = errors.New("invalid DPoP proof")
+	errDPoPHTUMismatch     = errors.New("invalid DPoP proof htu")
+	errDPoPIatInvalid      = errors.New("invalid DPoP proof iat")
+	errDPoPReplay          = errors.New("replayed DPoP proof")
+	errDPoPJKTMismatch     = errors.New("invalid DPoP proof")
+)
+
+func parseAuthorizationDPoP(header string) (string, error) {
+	if strings.TrimSpace(header) == "" {
+		return "", errJWTMissing
+	}
+	parts := strings.SplitN(strings.TrimSpace(header), " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "DPoP") {
+		return "", errJWTSchemeInvalid
+	}
+	if strings.TrimSpace(parts[1]) == "" {
+		return "", errJWTInvalid
+	}
+	return strings.TrimSpace(parts[1]), nil
+}
+
+type tokenClaims struct {
+	Subject     string
+	Issuer      string
+	Audience    []string
+	ExpiresAt   int64
+	NotBefore   int64
+	AZP         string
+	ClientID    string
+	CnfJKT      string
+	RawRolesMap map[string]any
+}
+
+func (a *authContext) validateAccessToken(token string) (*tokenClaims, bool, error) {
+	header, payload, sig, input, err := parseJWT(token)
+	if err != nil {
+		return nil, false, errJWTInvalid
+	}
+	kid, _ := header["kid"].(string)
+	if kid == "" {
+		return nil, false, errJWTInvalid
+	}
+
+	key, found := a.jwks.get(kid)
+	if !found {
+		return nil, false, errUnknownKID
+	}
+	if err := verifyJWS(header, input, sig, key); err != nil {
+		return nil, true, errJWTInvalid
+	}
+
+	claims := &tokenClaims{
+		RawRolesMap: map[string]any{},
+	}
+	if err := decodeTokenClaims(payload, claims); err != nil {
+		return nil, true, errJWTInvalid
+	}
+	if err := a.validateTokenClaims(claims); err != nil {
+		return nil, true, err
+	}
+	return claims, true, nil
+}
+
+func (a *authContext) validateTokenClaims(c *tokenClaims) error {
+	if c.Subject == "" {
+		return errJWTInvalid
+	}
+	if c.Issuer != a.cfg.KeycloakIssuerURL {
+		return errJWTInvalid
+	}
+	if !contains(c.Audience, a.cfg.KeycloakAudience) {
+		return errJWTInvalid
+	}
+	now := time.Now().Unix()
+	if c.ExpiresAt <= now || (c.NotBefore != 0 && c.NotBefore > now) {
+		return errJWTInvalid
+	}
+	client := c.AZP
+	if client == "" {
+		client = c.ClientID
+	}
+	if client != a.cfg.KeycloakAdminUIClient {
+		return errInvalidAdminClient
+	}
+	if c.CnfJKT == "" {
+		return errJWTInvalid
+	}
+	rolesAny, ok := c.RawRolesMap[a.cfg.KeycloakAudience]
+	if !ok {
+		return fmt.Errorf("%w %s", errMissingRequiredRole, a.cfg.KeycloakRequiredRole)
+	}
+	rolesObj, ok := rolesAny.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w %s", errMissingRequiredRole, a.cfg.KeycloakRequiredRole)
+	}
+	rv, ok := rolesObj["roles"].([]any)
+	if !ok {
+		return fmt.Errorf("%w %s", errMissingRequiredRole, a.cfg.KeycloakRequiredRole)
+	}
+	hasRole := false
+	for _, v := range rv {
+		if s, ok := v.(string); ok && s == a.cfg.KeycloakRequiredRole {
+			hasRole = true
+			break
+		}
+	}
+	if !hasRole {
+		return fmt.Errorf("%w %s", errMissingRequiredRole, a.cfg.KeycloakRequiredRole)
+	}
+	return nil
+}
+
+func (a *authContext) validateDPoPProof(r *http.Request, proof, accessToken, expectedJKT string) error {
+	header, payload, sig, input, err := parseJWT(proof)
+	if err != nil {
+		return errDPoPInvalid
+	}
+	jwkVal, ok := header["jwk"]
+	if !ok {
+		return errDPoPInvalid
+	}
+	jwkMap, ok := jwkVal.(map[string]any)
+	if !ok {
+		return errDPoPInvalid
+	}
+	pubKey, err := parseJWKPublicKey(jwkMap)
+	if err != nil {
+		return errDPoPInvalid
+	}
+	if err := verifyJWS(header, input, sig, pubKey); err != nil {
+		return errDPoPInvalid
+	}
+
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return errDPoPInvalid
+	}
+	if method, _ := claims["htm"].(string); method != r.Method {
+		return errDPoPInvalid
+	}
+	htuExpected, err := a.expectedHTU(r)
+	if err != nil {
+		return errInvalidConfig
+	}
+	htuActual, _ := claims["htu"].(string)
+	if htuActual != htuExpected {
+		return errDPoPHTUMismatch
+	}
+	iat, ok := numberToInt64(claims["iat"])
+	if !ok {
+		return errDPoPIatInvalid
+	}
+	now := time.Now().Unix()
+	if iat < now-int64(a.cfg.DPoPProofMaxAgeSeconds)-int64(a.cfg.DPoPClockSkewSeconds) ||
+		iat > now+int64(a.cfg.DPoPClockSkewSeconds) {
+		return errDPoPIatInvalid
+	}
+	ath, _ := claims["ath"].(string)
+	expectedATH := hashAccessToken(accessToken)
+	if ath != expectedATH {
+		return errDPoPInvalid
+	}
+	jti, _ := claims["jti"].(string)
+	if strings.TrimSpace(jti) == "" {
+		return errDPoPInvalid
+	}
+	if !a.replay.tryStore(jti) {
+		return errDPoPReplay
+	}
+	jkt, err := jwkThumbprint(jwkMap)
+	if err != nil {
+		return errDPoPInvalid
+	}
+	if jkt != expectedJKT {
+		return errDPoPJKTMismatch
+	}
+	return nil
+}
+
+func (a *authContext) expectedHTU(r *http.Request) (string, error) {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	host := r.Host
+	if host == "" {
+		return "", errors.New("missing host")
+	}
+	if a.isTrustedRemote(r.RemoteAddr) {
+		if v := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); v != "" {
+			scheme = strings.ToLower(v)
+		}
+		if v := strings.TrimSpace(r.Header.Get("X-Forwarded-Host")); v != "" {
+			host = v
+		}
+		if fp := strings.TrimSpace(r.Header.Get("X-Forwarded-Port")); fp != "" {
+			h, p, err := net.SplitHostPort(host)
+			if err != nil {
+				h = host
+				p = ""
+			}
+			if p == "" && ((scheme == "https" && fp != "443") || (scheme == "http" && fp != "80")) {
+				host = net.JoinHostPort(h, fp)
+			}
+		}
+	}
+	u := url.URL{
+		Scheme: scheme,
+		Host:   host,
+		Path:   r.URL.Path,
+	}
+	return u.String(), nil
+}
+
+func (a *authContext) isTrustedRemote(remote string) bool {
+	host, _, err := net.SplitHostPort(remote)
+	if err != nil {
+		host = remote
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	for _, c := range a.trustedCIDRs {
+		if c.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+type jwksCache struct {
+	mu         sync.RWMutex
+	keys       map[string]any
+	lastSyncAt time.Time
+	ttl        time.Duration
+}
+
+func newJWKSCache(ttl time.Duration) *jwksCache {
+	return &jwksCache{keys: map[string]any{}, ttl: ttl}
+}
+
+func (j *jwksCache) get(kid string) (any, bool) {
+	j.mu.RLock()
+	key, ok := j.keys[kid]
+	stale := j.lastSyncAt.IsZero() || time.Since(j.lastSyncAt) > j.ttl
+	j.mu.RUnlock()
+	if ok || !stale {
+		return key, ok
+	}
+	return nil, false
+}
+
+func (j *jwksCache) refresh(ctx context.Context, client *http.Client, jwksURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("jwks status %d", resp.StatusCode)
+	}
+	var payload struct {
+		Keys []map[string]any `json:"keys"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return err
+	}
+	next := make(map[string]any, len(payload.Keys))
+	for _, k := range payload.Keys {
+		kid, _ := k["kid"].(string)
+		if strings.TrimSpace(kid) == "" {
+			continue
+		}
+		pub, err := parseJWKPublicKey(k)
+		if err != nil {
+			continue
+		}
+		next[kid] = pub
+	}
+	if len(next) == 0 {
+		return errors.New("no jwks keys")
+	}
+	j.mu.Lock()
+	j.keys = next
+	j.lastSyncAt = time.Now()
+	j.mu.Unlock()
+	return nil
+}
+
+type jtiReplayCache struct {
+	mu    sync.Mutex
+	items map[string]time.Time
+	ttl   time.Duration
+}
+
+func newJTIReplayCache(ttl time.Duration) *jtiReplayCache {
+	return &jtiReplayCache{
+		items: map[string]time.Time{},
+		ttl:   ttl,
+	}
+}
+
+func (c *jtiReplayCache) tryStore(jti string) bool {
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k, v := range c.items {
+		if now.After(v) {
+			delete(c.items, k)
+		}
+	}
+	if exp, ok := c.items[jti]; ok && now.Before(exp) {
+		return false
+	}
+	c.items[jti] = now.Add(c.ttl)
+	return true
+}
+
+func parseJWT(raw string) (map[string]any, []byte, []byte, []byte, error) {
+	parts := strings.Split(raw, ".")
+	if len(parts) != 3 {
+		return nil, nil, nil, nil, errors.New("invalid jwt")
+	}
+	headBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	var header map[string]any
+	if err := json.Unmarshal(headBytes, &header); err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return header, payloadBytes, sig, []byte(parts[0] + "." + parts[1]), nil
+}
+
+func verifyJWS(header map[string]any, signedContent, sig []byte, key any) error {
+	alg, _ := header["alg"].(string)
+	switch alg {
+	case "RS256":
+		pub, ok := key.(*rsa.PublicKey)
+		if !ok {
+			return errors.New("invalid key type")
+		}
+		h := sha256.Sum256(signedContent)
+		return rsa.VerifyPKCS1v15(pub, crypto.SHA256, h[:], sig)
+	case "ES256":
+		pub, ok := key.(*ecdsa.PublicKey)
+		if !ok {
+			return errors.New("invalid key type")
+		}
+		if len(sig) != 64 {
+			return errors.New("invalid ecdsa signature size")
+		}
+		r := new(big.Int).SetBytes(sig[:32])
+		s := new(big.Int).SetBytes(sig[32:])
+		h := sha256.Sum256(signedContent)
+		if !ecdsa.Verify(pub, h[:], r, s) {
+			return errors.New("invalid ecdsa signature")
+		}
+		return nil
+	default:
+		return errors.New("unsupported jwt alg")
+	}
+}
+
+func parseJWKPublicKey(jwk map[string]any) (any, error) {
+	kty, _ := jwk["kty"].(string)
+	switch kty {
+	case "RSA":
+		nS, _ := jwk["n"].(string)
+		eS, _ := jwk["e"].(string)
+		nB, err := base64.RawURLEncoding.DecodeString(nS)
+		if err != nil {
+			return nil, err
+		}
+		eB, err := base64.RawURLEncoding.DecodeString(eS)
+		if err != nil {
+			return nil, err
+		}
+		n := new(big.Int).SetBytes(nB)
+		e := int(new(big.Int).SetBytes(eB).Int64())
+		if e <= 0 {
+			return nil, errors.New("invalid exponent")
+		}
+		return &rsa.PublicKey{N: n, E: e}, nil
+	case "EC":
+		crv, _ := jwk["crv"].(string)
+		xS, _ := jwk["x"].(string)
+		yS, _ := jwk["y"].(string)
+		xB, err := base64.RawURLEncoding.DecodeString(xS)
+		if err != nil {
+			return nil, err
+		}
+		yB, err := base64.RawURLEncoding.DecodeString(yS)
+		if err != nil {
+			return nil, err
+		}
+		var curve elliptic.Curve
+		switch crv {
+		case "P-256":
+			curve = elliptic.P256()
+		default:
+			return nil, errors.New("unsupported curve")
+		}
+		pub := &ecdsa.PublicKey{
+			Curve: curve,
+			X:     new(big.Int).SetBytes(xB),
+			Y:     new(big.Int).SetBytes(yB),
+		}
+		if !pub.Curve.IsOnCurve(pub.X, pub.Y) {
+			return nil, errors.New("invalid point")
+		}
+		return pub, nil
+	default:
+		return nil, errors.New("unsupported kty")
+	}
+}
+
+func decodeTokenClaims(payload []byte, out *tokenClaims) error {
+	var raw map[string]any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return err
+	}
+	if sub, _ := raw["sub"].(string); sub != "" {
+		out.Subject = sub
+	}
+	if iss, _ := raw["iss"].(string); iss != "" {
+		out.Issuer = iss
+	}
+	if audS, ok := raw["aud"].(string); ok && audS != "" {
+		out.Audience = []string{audS}
+	} else if audArr, ok := raw["aud"].([]any); ok {
+		for _, v := range audArr {
+			if s, ok := v.(string); ok {
+				out.Audience = append(out.Audience, s)
+			}
+		}
+	}
+	if exp, ok := numberToInt64(raw["exp"]); ok {
+		out.ExpiresAt = exp
+	}
+	if nbf, ok := numberToInt64(raw["nbf"]); ok {
+		out.NotBefore = nbf
+	}
+	out.AZP, _ = raw["azp"].(string)
+	out.ClientID, _ = raw["client_id"].(string)
+	if cnf, ok := raw["cnf"].(map[string]any); ok {
+		out.CnfJKT, _ = cnf["jkt"].(string)
+	}
+	if rsrc, ok := raw["resource_access"].(map[string]any); ok {
+		out.RawRolesMap = rsrc
+	}
+	return nil
+}
+
+func numberToInt64(v any) (int64, bool) {
+	switch t := v.(type) {
+	case float64:
+		return int64(t), true
+	case int64:
+		return t, true
+	case int:
+		return int64(t), true
+	case json.Number:
+		i, err := t.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return i, true
+	default:
+		return 0, false
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, it := range s {
+		if it == v {
+			return true
+		}
+	}
+	return false
+}
+
+func hashAccessToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func extractJWTKid(token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	headBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return ""
+	}
+	var header map[string]any
+	if err := json.Unmarshal(headBytes, &header); err != nil {
+		return ""
+	}
+	kid, _ := header["kid"].(string)
+	return kid
+}
+
+func logAdminAuth(log *logger.Logrus, reason string, r *http.Request, kid string, trustedProxy *bool) {
+	l := log.
+		WithField("reason", reason).
+		WithField("method", r.Method).
+		WithField("path", r.URL.Path).
+		WithField("remote_addr", r.RemoteAddr).
+		WithField("request_id", requestIDFromCtx(r))
+	if kid != "" {
+		l = l.WithField("kid", kid)
+	}
+	if trustedProxy != nil {
+		l = l.WithField("trusted_proxy", *trustedProxy)
+	}
+	l.Infof("admin_auth")
+}
+
+func jwkThumbprint(jwk map[string]any) (string, error) {
+	kty, _ := jwk["kty"].(string)
+	var canonical string
+	switch kty {
+	case "RSA":
+		e, _ := jwk["e"].(string)
+		n, _ := jwk["n"].(string)
+		if e == "" || n == "" {
+			return "", errors.New("invalid rsa jwk")
+		}
+		canonical = `{"e":"` + e + `","kty":"RSA","n":"` + n + `"}`
+	case "EC":
+		crv, _ := jwk["crv"].(string)
+		x, _ := jwk["x"].(string)
+		y, _ := jwk["y"].(string)
+		if crv == "" || x == "" || y == "" {
+			return "", errors.New("invalid ec jwk")
+		}
+		canonical = `{"crv":"` + crv + `","kty":"EC","x":"` + x + `","y":"` + y + `"}`
+	default:
+		return "", errors.New("unsupported kty")
+	}
+	sum := sha256.Sum256([]byte(canonical))
+	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
+}

--- a/cds_service/internal/http/middleware.go
+++ b/cds_service/internal/http/middleware.go
@@ -31,10 +31,15 @@ type ctxKey string
 
 const ctxKeyOwnerScope ctxKey = "ownerScope"
 
-// Device mTLS guard (existing behavior)
-func RequireClientCert(next http.Handler) http.Handler {
+// Device mTLS guard (trust mTLS verification header only from trusted proxies)
+func RequireClientCert(cfg *config.Config, next http.Handler) http.Handler {
+	actx := getAuthContext(cfg)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-SSL-Client-Verify") != "SUCCESS" {
+		if !actx.isTrustedRemote(r.RemoteAddr) {
+			http.Error(w, "client certificate required", http.StatusUnauthorized)
+			return
+		}
+		if strings.TrimSpace(r.Header.Get("X-SSL-Client-Verify")) != "SUCCESS" {
 			http.Error(w, "client certificate required", http.StatusUnauthorized)
 			return
 		}

--- a/cds_service/internal/http/middleware_security_test.go
+++ b/cds_service/internal/http/middleware_security_test.go
@@ -1,0 +1,727 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ */
+package http
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"cds/internal/config"
+)
+
+type testKeyMaterial struct {
+	key *rsa.PrivateKey
+	kid string
+}
+
+type jwksState struct {
+	mu   sync.Mutex
+	keys []map[string]any
+	hits int
+}
+
+func (s *jwksState) setKeys(keys []map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keys = keys
+}
+
+func (s *jwksState) hitCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hits
+}
+
+func (s *jwksState) handler(w http.ResponseWriter, _ *http.Request) {
+	s.mu.Lock()
+	s.hits++
+	keys := s.keys
+	s.mu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"keys": keys})
+}
+
+func newRSAKey(t *testing.T, kid string) *testKeyMaterial {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	return &testKeyMaterial{key: k, kid: kid}
+}
+
+func jwkFromRSA(km *testKeyMaterial) map[string]any {
+	pub := km.key.Public().(*rsa.PublicKey)
+	return map[string]any{
+		"kty": "RSA",
+		"kid": km.kid,
+		"alg": "RS256",
+		"use": "sig",
+		"n":   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+	}
+}
+
+func signJWTForTest(t *testing.T, privateKey *rsa.PrivateKey, header map[string]any, payload map[string]any) string {
+	t.Helper()
+	hb, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+	pb, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	unsigned := base64.RawURLEncoding.EncodeToString(hb) + "." + base64.RawURLEncoding.EncodeToString(pb)
+	h := sha256.Sum256([]byte(unsigned))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, h[:])
+	if err != nil {
+		t.Fatalf("sign jwt: %v", err)
+	}
+	return unsigned + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func thumbprintRSA(pub *rsa.PublicKey) string {
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	canonical := `{"e":"` + e + `","kty":"RSA","n":"` + n + `"}`
+	sum := sha256.Sum256([]byte(canonical))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+type tokenOpts struct {
+	issuer       string
+	audience     []string
+	clientID     string
+	roleAudience string
+	roles        []string
+	includeCNF   bool
+	kid          string
+	expiryOffset time.Duration
+}
+
+func buildAccessToken(t *testing.T, signer *testKeyMaterial, dpopPub *rsa.PublicKey, opts tokenOpts) string {
+	t.Helper()
+	now := time.Now()
+	issuer := opts.issuer
+	if issuer == "" {
+		issuer = "https://keycloak.example.com/realms/cds"
+	}
+	aud := opts.audience
+	if len(aud) == 0 {
+		aud = []string{"cds-service"}
+	}
+	clientID := opts.clientID
+	if clientID == "" {
+		clientID = "cds-admin-ui"
+	}
+	roleAud := opts.roleAudience
+	if roleAud == "" {
+		roleAud = "cds-service"
+	}
+	roles := opts.roles
+	if roles == nil {
+		roles = []string{"cds-admin"}
+	}
+	exp := now.Add(1 * time.Hour)
+	if opts.expiryOffset != 0 {
+		exp = now.Add(opts.expiryOffset)
+	}
+	payload := map[string]any{
+		"iss": issuer,
+		"sub": "admin-subject",
+		"aud": aud,
+		"exp": exp.Unix(),
+		"iat": now.Unix(),
+		"azp": clientID,
+		"resource_access": map[string]any{
+			roleAud: map[string]any{
+				"roles": roles,
+			},
+		},
+	}
+	if opts.includeCNF || opts.includeCNF == false {
+		// default include unless explicitly false via pointerless toggle check below
+	}
+	if opts.includeCNF || !opts.includeCNF && dpopPub != nil {
+		if opts.includeCNF {
+			payload["cnf"] = map[string]any{"jkt": thumbprintRSA(dpopPub)}
+		}
+	}
+	if !opts.includeCNF {
+		delete(payload, "cnf")
+	}
+	kid := signer.kid
+	if opts.kid != "" {
+		kid = opts.kid
+	}
+	return signJWTForTest(t, signer.key, map[string]any{
+		"alg": "RS256",
+		"typ": "JWT",
+		"kid": kid,
+	}, payload)
+}
+
+type dpopOpts struct {
+	method    string
+	htu       string
+	iat       int64
+	jti       string
+	ath       string
+	tamperSig bool
+}
+
+func buildDPoPProof(t *testing.T, key *rsa.PrivateKey, opts dpopOpts) string {
+	t.Helper()
+	pub := key.Public().(*rsa.PublicKey)
+	method := opts.method
+	if method == "" {
+		method = http.MethodGet
+	}
+	iat := opts.iat
+	if iat == 0 {
+		iat = time.Now().Unix()
+	}
+	jti := opts.jti
+	if jti == "" {
+		jti = "jti-" + base64.RawURLEncoding.EncodeToString([]byte(time.Now().String()))
+	}
+	proof := signJWTForTest(t, key, map[string]any{
+		"alg": "RS256",
+		"typ": "dpop+jwt",
+		"jwk": map[string]any{
+			"kty": "RSA",
+			"n":   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+			"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+		},
+	}, map[string]any{
+		"htu": opts.htu,
+		"htm": method,
+		"iat": iat,
+		"jti": jti,
+		"ath": opts.ath,
+	})
+	if opts.tamperSig {
+		parts := strings.Split(proof, ".")
+		if len(parts) != 3 {
+			return proof
+		}
+		payload := parts[1]
+		if len(payload) > 0 {
+			if strings.HasSuffix(payload, "A") {
+				payload = payload[:len(payload)-1] + "B"
+			} else {
+				payload = payload[:len(payload)-1] + "A"
+			}
+			parts[1] = payload
+		}
+		return strings.Join(parts, ".")
+	}
+	return proof
+}
+
+func newMiddlewareTestConfig(jwksURL string, dpopRequired bool) *config.Config {
+	return &config.Config{
+		AuthMode:               "keycloak-dpop",
+		KeycloakIssuerURL:      "https://keycloak.example.com/realms/cds",
+		KeycloakJWKSURL:        jwksURL,
+		KeycloakAudience:       "cds-service",
+		KeycloakRequiredRole:   "cds-admin",
+		KeycloakAdminUIClient:  "cds-admin-ui",
+		DPoPRequired:           dpopRequired,
+		DPoPJtiCacheTTLSeconds: 300,
+		DPoPProofMaxAgeSeconds: 300,
+		DPoPClockSkewSeconds:   30,
+		JWKSCacheTTLSeconds:    300,
+		TrustedProxyCIDRs:      []string{"127.0.0.1/32"},
+	}
+}
+
+func executeAdminRequest(t *testing.T, cfg *config.Config, method, target, authorization, dpop, remoteAddr string, extraHeaders map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	h := RequireKeycloakDPoPAdmin(cfg, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(method, target, nil)
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+	if dpop != "" {
+		req.Header.Set("DPoP", dpop)
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+	if remoteAddr != "" {
+		req.RemoteAddr = remoteAddr
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestAdminJWTValidationFailures(t *testing.T) {
+	tokenKey := newRSAKey(t, "kid-1")
+	dpopKey := newRSAKey(t, "dpop-1")
+	jwks := &jwksState{}
+	jwks.setKeys([]map[string]any{jwkFromRSA(tokenKey)})
+	srv := httptest.NewServer(http.HandlerFunc(jwks.handler))
+	defer srv.Close()
+
+	t.Run("missing Authorization rejected", func(t *testing.T) {
+		cfg := newMiddlewareTestConfig(srv.URL, false)
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "", "", "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "missing Authorization header") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("Bearer rejected", func(t *testing.T) {
+		cfg := newMiddlewareTestConfig(srv.URL, false)
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "Bearer token", "", "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "Authorization scheme must be DPoP") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("malformed token rejected", func(t *testing.T) {
+		cfg := newMiddlewareTestConfig(srv.URL, false)
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP not.a.jwt", "", "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid access token") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("wrong issuer rejected", func(t *testing.T) {
+		cfg := newMiddlewareTestConfig(srv.URL, false)
+		token := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{issuer: "https://wrong-issuer", includeCNF: true})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid access token") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("wrong audience rejected", func(t *testing.T) {
+		cfg := newMiddlewareTestConfig(srv.URL, false)
+		token := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{audience: []string{"other-service"}, includeCNF: true})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid access token") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("missing required role rejected", func(t *testing.T) {
+		cfg := newMiddlewareTestConfig(srv.URL, false)
+		token := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{roles: []string{}, includeCNF: true})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr.Code != http.StatusForbidden || !strings.Contains(rr.Body.String(), "missing required role") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("wrong role rejected", func(t *testing.T) {
+		cfg := newMiddlewareTestConfig(srv.URL, false)
+		token := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{roles: []string{"not-admin"}, includeCNF: true})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr.Code != http.StatusForbidden || !strings.Contains(rr.Body.String(), "missing required role") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("missing cnf.jkt rejected", func(t *testing.T) {
+		cfg := newMiddlewareTestConfig(srv.URL, false)
+		token := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{includeCNF: false})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid access token") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+func TestUnknownKIDRefreshBehavior(t *testing.T) {
+	tokenKey := newRSAKey(t, "kid-token")
+	dpopKey := newRSAKey(t, "kid-dpop")
+	jwks := &jwksState{}
+	jwks.setKeys([]map[string]any{})
+	srv := httptest.NewServer(http.HandlerFunc(jwks.handler))
+	defer srv.Close()
+
+	t.Run("unknown kid refresh succeeds when key appears", func(t *testing.T) {
+		jwks.setKeys([]map[string]any{jwkFromRSA(tokenKey)})
+		cfg := newMiddlewareTestConfig(srv.URL, false)
+		token := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{includeCNF: true})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+		if jwks.hitCount() != 1 {
+			t.Fatalf("expected one refresh hit, got %d", jwks.hitCount())
+		}
+	})
+
+	t.Run("unknown kid refresh fails when key still missing", func(t *testing.T) {
+		jwks2 := &jwksState{}
+		otherKey := newRSAKey(t, "other-kid")
+		jwks2.setKeys([]map[string]any{jwkFromRSA(otherKey)})
+		srv2 := httptest.NewServer(http.HandlerFunc(jwks2.handler))
+		defer srv2.Close()
+		cfg := newMiddlewareTestConfig(srv2.URL, false)
+		token := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{includeCNF: true})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "unknown access token kid after JWKS refresh") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+		if jwks2.hitCount() != 1 {
+			t.Fatalf("expected one refresh hit, got %d", jwks2.hitCount())
+		}
+	})
+}
+
+func TestDPoPValidationScenarios(t *testing.T) {
+	tokenKey := newRSAKey(t, "token-kid")
+	dpopKey := newRSAKey(t, "dpop-kid")
+	jwks := &jwksState{}
+	jwks.setKeys([]map[string]any{jwkFromRSA(tokenKey)})
+	srv := httptest.NewServer(http.HandlerFunc(jwks.handler))
+	defer srv.Close()
+
+	cfg := newMiddlewareTestConfig(srv.URL, true)
+	accessToken := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{includeCNF: true})
+	ath := hashAccessToken(accessToken)
+
+	t.Run("missing DPoP header rejected", func(t *testing.T) {
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, "", "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "missing DPoP proof") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("invalid DPoP signature rejected", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method:    http.MethodGet,
+			htu:       "http://example.com/v1/device",
+			ath:       ath,
+			jti:       "sig-invalid",
+			tamperSig: true,
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid DPoP proof") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("htm mismatch rejected", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodPost,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "wrong-htm",
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid DPoP proof") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("htu mismatch rejected", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/other",
+			ath:    ath,
+			jti:    "wrong-htu",
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid DPoP proof htu") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("htu ignores query string", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "htu-query",
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device?serial=abc", "DPoP "+accessToken, proof, "", nil)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("htu ignores fragment", func(t *testing.T) {
+		actx := getAuthContext(cfg)
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/v1/device", nil)
+		req.URL.Fragment = "frag"
+		got, err := actx.expectedHTU(req)
+		if err != nil {
+			t.Fatalf("expectedHTU err: %v", err)
+		}
+		if got != "http://example.com/v1/device" {
+			t.Fatalf("got %q", got)
+		}
+	})
+
+	t.Run("stale iat rejected", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "iat-stale",
+			iat:    time.Now().Add(-10 * time.Minute).Unix(),
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid DPoP proof iat") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("future iat beyond skew rejected", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "iat-future",
+			iat:    time.Now().Add(2 * time.Minute).Unix(),
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid DPoP proof iat") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("ath mismatch rejected", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/device",
+			ath:    "bad-ath",
+			jti:    "bad-ath",
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid DPoP proof") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("cnf.jkt mismatch rejected", func(t *testing.T) {
+		otherKey := newRSAKey(t, "other-dpop")
+		proof := buildDPoPProof(t, otherKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "mismatch-jkt",
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid DPoP proof") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("replayed jti rejected and new jti accepted", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "same-jti",
+		})
+		rr1 := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
+		if rr1.Code != http.StatusNoContent {
+			t.Fatalf("first got %d body=%q", rr1.Code, rr1.Body.String())
+		}
+		rr2 := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
+		if rr2.Code != http.StatusUnauthorized || !strings.Contains(rr2.Body.String(), "replayed DPoP proof") {
+			t.Fatalf("second got %d body=%q", rr2.Code, rr2.Body.String())
+		}
+		proof2 := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "new-jti",
+		})
+		rr3 := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof2, "", nil)
+		if rr3.Code != http.StatusNoContent {
+			t.Fatalf("third got %d body=%q", rr3.Code, rr3.Body.String())
+		}
+	})
+}
+
+func TestTrustedProxyHTUReconstruction(t *testing.T) {
+	tokenKey := newRSAKey(t, "token-kid")
+	dpopKey := newRSAKey(t, "dpop-kid")
+	jwks := &jwksState{}
+	jwks.setKeys([]map[string]any{jwkFromRSA(tokenKey)})
+	srv := httptest.NewServer(http.HandlerFunc(jwks.handler))
+	defer srv.Close()
+
+	cfg := newMiddlewareTestConfig(srv.URL, true)
+	accessToken := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{includeCNF: true})
+	ath := hashAccessToken(accessToken)
+
+	t.Run("trusted proxy uses X-Forwarded headers", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "https://proxy.example.com:8443/v1/device",
+			ath:    ath,
+			jti:    "trusted-forwarded",
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://internal/v1/device", "DPoP "+accessToken, proof, "127.0.0.1:60000", map[string]string{
+			"X-Forwarded-Proto": "https",
+			"X-Forwarded-Host":  "proxy.example.com",
+			"X-Forwarded-Port":  "8443",
+		})
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("untrusted remote ignores X-Forwarded headers", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "untrusted-ignore",
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "198.51.100.10:34567", map[string]string{
+			"X-Forwarded-Proto": "https",
+			"X-Forwarded-Host":  "evil.example.com",
+			"X-Forwarded-Port":  "9443",
+		})
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("Forwarded header explicitly ignored", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "forwarded-ignored",
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "198.51.100.10:34567", map[string]string{
+			"Forwarded": "proto=https;host=forwarded.example.com:443",
+		})
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("default ports normalized for http and https", func(t *testing.T) {
+		proofHTTP := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "http://proxy.example.com/v1/device",
+			ath:    ath,
+			jti:    "default-80",
+		})
+		rrHTTP := executeAdminRequest(t, cfg, http.MethodGet, "http://internal/v1/device", "DPoP "+accessToken, proofHTTP, "127.0.0.1:60000", map[string]string{
+			"X-Forwarded-Proto": "http",
+			"X-Forwarded-Host":  "proxy.example.com",
+			"X-Forwarded-Port":  "80",
+		})
+		if rrHTTP.Code != http.StatusNoContent {
+			t.Fatalf("http got %d body=%q", rrHTTP.Code, rrHTTP.Body.String())
+		}
+		proofHTTPS := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "https://proxy.example.com/v1/device",
+			ath:    ath,
+			jti:    "default-443",
+		})
+		rrHTTPS := executeAdminRequest(t, cfg, http.MethodGet, "http://internal/v1/device", "DPoP "+accessToken, proofHTTPS, "127.0.0.1:60000", map[string]string{
+			"X-Forwarded-Proto": "https",
+			"X-Forwarded-Host":  "proxy.example.com",
+			"X-Forwarded-Port":  "443",
+		})
+		if rrHTTPS.Code != http.StatusNoContent {
+			t.Fatalf("https got %d body=%q", rrHTTPS.Code, rrHTTPS.Body.String())
+		}
+	})
+
+	t.Run("non-default forwarded port included in htu", func(t *testing.T) {
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			method: http.MethodGet,
+			htu:    "https://proxy.example.com:8443/v1/device",
+			ath:    ath,
+			jti:    "nondefault-port",
+		})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://internal/v1/device", "DPoP "+accessToken, proof, "127.0.0.1:60000", map[string]string{
+			"X-Forwarded-Proto": "https",
+			"X-Forwarded-Host":  "proxy.example.com",
+			"X-Forwarded-Port":  "8443",
+		})
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+func TestRouteBehaviorWithNewAuthContract(t *testing.T) {
+	tokenKey := newRSAKey(t, "token-kid")
+	jwks := &jwksState{}
+	jwks.setKeys([]map[string]any{jwkFromRSA(tokenKey)})
+	srv := httptest.NewServer(http.HandlerFunc(jwks.handler))
+	defer srv.Close()
+
+	cfg := newMiddlewareTestConfig(srv.URL, true)
+	router := NewRouterWithConfig(cfg, nil)
+
+	t.Run("X-Auth-Token alone rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/device", nil)
+		req.Header.Set("X-Auth-Token", "legacy-token")
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("DELETE /v1/device without serial is not delete success path", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/v1/device", nil)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code == http.StatusNoContent {
+			t.Fatalf("unexpected success for DELETE /v1/device")
+		}
+	})
+
+	t.Run("health endpoint does not require auth", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("device-facing endpoint uses mTLS header simulation and no DPoP", func(t *testing.T) {
+		mtlsOnly := RequireClientCert(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		reqNoCert := httptest.NewRequest(http.MethodGet, "/v1/devices/abc", nil)
+		rrNoCert := httptest.NewRecorder()
+		mtlsOnly.ServeHTTP(rrNoCert, reqNoCert)
+		if rrNoCert.Code != http.StatusUnauthorized {
+			t.Fatalf("without cert got %d body=%q", rrNoCert.Code, rrNoCert.Body.String())
+		}
+		reqWithCert := httptest.NewRequest(http.MethodGet, "/v1/devices/abc", nil)
+		reqWithCert.Header.Set("X-SSL-Client-Verify", "SUCCESS")
+		rrWithCert := httptest.NewRecorder()
+		mtlsOnly.ServeHTTP(rrWithCert, reqWithCert)
+		if rrWithCert.Code != http.StatusNoContent {
+			t.Fatalf("with cert got %d body=%q", rrWithCert.Code, rrWithCert.Body.String())
+		}
+	})
+}

--- a/cds_service/internal/http/middleware_security_test.go
+++ b/cds_service/internal/http/middleware_security_test.go
@@ -22,6 +22,33 @@ import (
 	"cds/internal/config"
 )
 
+func TestJWKThumbprintCanonicalizationNoBackslashes(t *testing.T) {
+	jwk := map[string]any{
+		"kty": "RSA",
+		"e":   "AQAB",
+		"n":   "abc123",
+	}
+	got, err := jwkThumbprint(jwk)
+	if err != nil {
+		t.Fatalf("jwkThumbprint failed: %v", err)
+	}
+	// Expected hash is based on RFC 7638-style canonical JSON (no backslashes).
+	canonical := `{"e":"AQAB","kty":"RSA","n":"abc123"}`
+	sum := sha256.Sum256([]byte(canonical))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if got != want {
+		t.Fatalf("thumbprint mismatch: got=%q want=%q", got, want)
+	}
+
+	// Guardrail: do not hash a backslash-escaped pseudo-JSON string.
+	badCanonical := `{\"e\":\"AQAB\",\"kty\":\"RSA\",\"n\":\"abc123\"}`
+	badSum := sha256.Sum256([]byte(badCanonical))
+	bad := base64.RawURLEncoding.EncodeToString(badSum[:])
+	if got == bad {
+		t.Fatalf("thumbprint unexpectedly matches backslash-escaped canonical form")
+	}
+}
+
 type testKeyMaterial struct {
 	key *rsa.PrivateKey
 	kid string

--- a/cds_service/internal/http/middleware_security_test.go
+++ b/cds_service/internal/http/middleware_security_test.go
@@ -415,6 +415,71 @@ func TestUnknownKIDRefreshBehavior(t *testing.T) {
 			t.Fatalf("expected one refresh hit, got %d", jwks2.hitCount())
 		}
 	})
+
+	t.Run("stale cache refreshes even when kid is known", func(t *testing.T) {
+		jwks3 := &jwksState{}
+		jwks3.setKeys([]map[string]any{jwkFromRSA(tokenKey)})
+		srv3 := httptest.NewServer(http.HandlerFunc(jwks3.handler))
+		defer srv3.Close()
+
+		cfg := newMiddlewareTestConfig(srv3.URL, false)
+		cfg.JWKSCacheTTLSeconds = 1
+		token := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{includeCNF: true})
+
+		rr1 := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr1.Code != http.StatusNoContent {
+			t.Fatalf("first got %d body=%q", rr1.Code, rr1.Body.String())
+		}
+		if jwks3.hitCount() != 1 {
+			t.Fatalf("expected first refresh hit count to be 1, got %d", jwks3.hitCount())
+		}
+
+		actx := getAuthContext(cfg)
+		actx.jwks.mu.Lock()
+		actx.jwks.lastSyncAt = time.Now().Add(-2 * actx.jwks.ttl)
+		actx.jwks.mu.Unlock()
+
+		rr2 := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr2.Code != http.StatusNoContent {
+			t.Fatalf("second got %d body=%q", rr2.Code, rr2.Body.String())
+		}
+		if jwks3.hitCount() != 2 {
+			t.Fatalf("expected stale-cache refresh hit count to be 2, got %d", jwks3.hitCount())
+		}
+	})
+
+	t.Run("stale known kid refresh fails when JWKS refresh fails", func(t *testing.T) {
+		jwks4 := &jwksState{}
+		jwks4.setKeys([]map[string]any{jwkFromRSA(tokenKey)})
+		srv4 := httptest.NewServer(http.HandlerFunc(jwks4.handler))
+		defer srv4.Close()
+
+		cfg := newMiddlewareTestConfig(srv4.URL, false)
+		cfg.JWKSCacheTTLSeconds = 300
+		token := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{includeCNF: true})
+
+		rr1 := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr1.Code != http.StatusNoContent {
+			t.Fatalf("first got %d body=%q", rr1.Code, rr1.Body.String())
+		}
+		if jwks4.hitCount() != 1 {
+			t.Fatalf("expected first refresh hit count to be 1, got %d", jwks4.hitCount())
+		}
+
+		actx := getAuthContext(cfg)
+		actx.jwks.mu.Lock()
+		actx.jwks.lastSyncAt = time.Now().Add(-2 * actx.jwks.ttl)
+		actx.jwks.mu.Unlock()
+		jwks4.setKeys([]map[string]any{})
+
+		rr2 := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr2.Code != http.StatusInternalServerError || !strings.Contains(rr2.Body.String(), "failed to fetch Keycloak JWKS") {
+			t.Fatalf("second got %d body=%q", rr2.Code, rr2.Body.String())
+		}
+		if jwks4.hitCount() != 2 {
+			t.Fatalf("expected second refresh attempt, hit count=2 got %d", jwks4.hitCount())
+		}
+	})
 }
 
 func TestDPoPValidationScenarios(t *testing.T) {

--- a/cds_service/internal/http/middleware_security_test.go
+++ b/cds_service/internal/http/middleware_security_test.go
@@ -799,21 +799,31 @@ func TestRouteBehaviorWithNewAuthContract(t *testing.T) {
 	})
 
 	t.Run("device-facing endpoint uses mTLS header simulation and no DPoP", func(t *testing.T) {
-		mtlsOnly := RequireClientCert(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mtlsOnly := RequireClientCert(cfg, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		}))
 		reqNoCert := httptest.NewRequest(http.MethodGet, "/v1/devices/abc", nil)
+		reqNoCert.RemoteAddr = "127.0.0.1:12345"
 		rrNoCert := httptest.NewRecorder()
 		mtlsOnly.ServeHTTP(rrNoCert, reqNoCert)
 		if rrNoCert.Code != http.StatusUnauthorized {
 			t.Fatalf("without cert got %d body=%q", rrNoCert.Code, rrNoCert.Body.String())
 		}
 		reqWithCert := httptest.NewRequest(http.MethodGet, "/v1/devices/abc", nil)
+		reqWithCert.RemoteAddr = "127.0.0.1:12345"
 		reqWithCert.Header.Set("X-SSL-Client-Verify", "SUCCESS")
 		rrWithCert := httptest.NewRecorder()
 		mtlsOnly.ServeHTTP(rrWithCert, reqWithCert)
 		if rrWithCert.Code != http.StatusNoContent {
 			t.Fatalf("with cert got %d body=%q", rrWithCert.Code, rrWithCert.Body.String())
+		}
+		reqSpoofed := httptest.NewRequest(http.MethodGet, "/v1/devices/abc", nil)
+		reqSpoofed.RemoteAddr = "203.0.113.10:12345"
+		reqSpoofed.Header.Set("X-SSL-Client-Verify", "SUCCESS")
+		rrSpoofed := httptest.NewRecorder()
+		mtlsOnly.ServeHTTP(rrSpoofed, reqSpoofed)
+		if rrSpoofed.Code != http.StatusUnauthorized {
+			t.Fatalf("spoofed cert header got %d body=%q", rrSpoofed.Code, rrSpoofed.Body.String())
 		}
 	})
 }

--- a/cds_service/internal/http/middleware_security_test.go
+++ b/cds_service/internal/http/middleware_security_test.go
@@ -5,6 +5,9 @@
 package http
 
 import (
+	"bytes"
+	"cds/internal/adapters/postgres"
+	"cds/internal/services"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
@@ -137,6 +140,7 @@ type tokenOpts struct {
 	roles        []string
 	includeCNF   bool
 	kid          string
+	alg          string
 	expiryOffset time.Duration
 }
 
@@ -195,8 +199,12 @@ func buildAccessToken(t *testing.T, signer *testKeyMaterial, dpopPub *rsa.Public
 	if opts.kid != "" {
 		kid = opts.kid
 	}
+	alg := "RS256"
+	if opts.alg != "" {
+		alg = opts.alg
+	}
 	return signJWTForTest(t, signer.key, map[string]any{
-		"alg": "RS256",
+		"alg": alg,
 		"typ": "JWT",
 		"kid": kid,
 	}, payload)
@@ -208,6 +216,7 @@ type dpopOpts struct {
 	iat       int64
 	jti       string
 	ath       string
+	alg       string
 	tamperSig bool
 }
 
@@ -227,7 +236,12 @@ func buildDPoPProof(t *testing.T, key *rsa.PrivateKey, opts dpopOpts) string {
 		jti = "jti-" + base64.RawURLEncoding.EncodeToString([]byte(time.Now().String()))
 	}
 	proof := signJWTForTest(t, key, map[string]any{
-		"alg": "RS256",
+		"alg": func() string {
+			if opts.alg != "" {
+				return opts.alg
+			}
+			return "RS256"
+		}(),
 		"typ": "dpop+jwt",
 		"jwk": map[string]any{
 			"kty": "RSA",
@@ -268,6 +282,8 @@ func newMiddlewareTestConfig(jwksURL string, dpopRequired bool) *config.Config {
 		KeycloakAudience:       "cds-service",
 		KeycloakRequiredRole:   "cds-admin",
 		KeycloakAdminUIClient:  "cds-admin-ui",
+		KeycloakAccessTokenAlg: "RS256",
+		DPoPAllowedAlgs:        []string{"ES256", "RS256"},
 		DPoPRequired:           dpopRequired,
 		DPoPJtiCacheTTLSeconds: 300,
 		DPoPProofMaxAgeSeconds: 300,
@@ -283,6 +299,38 @@ func executeAdminRequest(t *testing.T, cfg *config.Config, method, target, autho
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	req := httptest.NewRequest(method, target, nil)
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+	if dpop != "" {
+		req.Header.Set("DPoP", dpop)
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+	if remoteAddr != "" {
+		req.RemoteAddr = remoteAddr
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+func executeAdminRequestWithBody(t *testing.T, cfg *config.Config, method, target, authorization, dpop, remoteAddr string, extraHeaders map[string]string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	svc := services.New(postgres.NewRepo(nil))
+	handler := NewDeviceHandler(svc)
+	var next http.HandlerFunc
+	switch method {
+	case http.MethodPost:
+		next = handler.Add
+	case http.MethodPut:
+		next = handler.Update
+	default:
+		t.Fatalf("unsupported method: %s", method)
+	}
+	h := RequireKeycloakDPoPAdmin(cfg, next)
+	req := httptest.NewRequest(method, target, bytes.NewReader(body))
 	if authorization != "" {
 		req.Header.Set("Authorization", authorization)
 	}
@@ -373,6 +421,56 @@ func TestAdminJWTValidationFailures(t *testing.T) {
 		token := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{includeCNF: false})
 		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
 		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid access token") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("access token with non configured alg rejected", func(t *testing.T) {
+		cfg := newMiddlewareTestConfig(srv.URL, false)
+		cfg.KeycloakAccessTokenAlg = "RS256"
+		token := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{includeCNF: true, alg: "ES256"})
+		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+token, "", "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid access token") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("POST body larger than limit returns 413", func(t *testing.T) {
+		cfg := newMiddlewareTestConfig(srv.URL, true)
+		accessToken := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{includeCNF: true})
+		ath := hashAccessToken(accessToken)
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			alg:    "RS256",
+			method: http.MethodPost,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "big-post-body",
+		})
+		bigPayload := []byte(`{"serial":"abc","controller_endpoint":"` + strings.Repeat("x", int(maxAdminRequestBodyBytes)) + `"}`)
+		rr := executeAdminRequestWithBody(t, cfg, http.MethodPost, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", map[string]string{
+			"Content-Type": "application/json",
+		}, bigPayload)
+		if rr.Code != http.StatusRequestEntityTooLarge || !strings.Contains(rr.Body.String(), "request body too large") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("PUT body larger than limit returns 413", func(t *testing.T) {
+		cfg := newMiddlewareTestConfig(srv.URL, true)
+		accessToken := buildAccessToken(t, tokenKey, dpopKey.key.Public().(*rsa.PublicKey), tokenOpts{includeCNF: true})
+		ath := hashAccessToken(accessToken)
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			alg:    "RS256",
+			method: http.MethodPut,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "big-put-body",
+		})
+		bigPayload := []byte(`{"serial":"abc","controller_endpoint":"` + strings.Repeat("x", int(maxAdminRequestBodyBytes)) + `"}`)
+		rr := executeAdminRequestWithBody(t, cfg, http.MethodPut, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", map[string]string{
+			"Content-Type": "application/json",
+		}, bigPayload)
+		if rr.Code != http.StatusRequestEntityTooLarge || !strings.Contains(rr.Body.String(), "request body too large") {
 			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
 		}
 	})
@@ -510,6 +608,38 @@ func TestDPoPValidationScenarios(t *testing.T) {
 			tamperSig: true,
 		})
 		rr := executeAdminRequest(t, cfg, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
+		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid DPoP proof") {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("DPoP proof with allowed alg accepted", func(t *testing.T) {
+		cfgAllowed := newMiddlewareTestConfig(srv.URL, true)
+		cfgAllowed.DPoPAllowedAlgs = []string{"RS256"}
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			alg:    "RS256",
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "alg-allowed",
+		})
+		rr := executeAdminRequest(t, cfgAllowed, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("DPoP proof with disallowed alg rejected", func(t *testing.T) {
+		cfgDisallowed := newMiddlewareTestConfig(srv.URL, true)
+		cfgDisallowed.DPoPAllowedAlgs = []string{"ES256"}
+		proof := buildDPoPProof(t, dpopKey.key, dpopOpts{
+			alg:    "RS256",
+			method: http.MethodGet,
+			htu:    "http://example.com/v1/device",
+			ath:    ath,
+			jti:    "alg-disallowed",
+		})
+		rr := executeAdminRequest(t, cfgDisallowed, http.MethodGet, "http://example.com/v1/device", "DPoP "+accessToken, proof, "", nil)
 		if rr.Code != http.StatusUnauthorized || !strings.Contains(rr.Body.String(), "invalid DPoP proof") {
 			t.Fatalf("got %d body=%q", rr.Code, rr.Body.String())
 		}

--- a/cds_service/internal/http/routes.go
+++ b/cds_service/internal/http/routes.go
@@ -16,7 +16,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("ok"))
 }
 
-func NewRouterWithConfig(cfg *config.Config, svc *services.DeviceService) *http.ServeMux {
+func NewRouterWithConfig(cfg *config.Config, svc *services.DeviceService) http.Handler {
 	h := NewDeviceHandler(svc)
 	mux := http.NewServeMux()
 
@@ -26,12 +26,12 @@ func NewRouterWithConfig(cfg *config.Config, svc *services.DeviceService) *http.
 	// Device (mTLS) route
 	mux.Handle("GET /v1/devices/{serial}", RequireClientCert(http.HandlerFunc(h.LookupBySerial)))
 
-	// Admin routes (validated token, userRole==root)
-	admin := func(hh http.HandlerFunc) http.Handler { return RequireValidatedAdmin(cfg, hh) }
+	// Admin routes (Keycloak DPoP)
+	admin := func(hh http.HandlerFunc) http.Handler { return RequireKeycloakDPoPAdmin(cfg, hh) }
 	mux.Handle("POST /v1/device", admin(http.HandlerFunc(h.Add)))
 	mux.Handle("PUT /v1/device", admin(http.HandlerFunc(h.Update)))
-	mux.Handle("DELETE /v1/device", admin(http.HandlerFunc(h.Delete)))
+	mux.Handle("DELETE /v1/device/{serial}", admin(http.HandlerFunc(h.Delete)))
 	mux.Handle("GET /v1/device", admin(http.HandlerFunc(h.List)))
 
-	return mux
+	return AccessLogger(mux)
 }

--- a/cds_service/internal/http/routes.go
+++ b/cds_service/internal/http/routes.go
@@ -24,7 +24,7 @@ func NewRouterWithConfig(cfg *config.Config, svc *services.DeviceService) http.H
 	mux.HandleFunc("GET /health", healthHandler)
 
 	// Device (mTLS) route
-	mux.Handle("GET /v1/devices/{serial}", RequireClientCert(http.HandlerFunc(h.LookupBySerial)))
+	mux.Handle("GET /v1/devices/{serial}", RequireClientCert(cfg, http.HandlerFunc(h.LookupBySerial)))
 
 	// Admin routes (Keycloak DPoP)
 	admin := func(hh http.HandlerFunc) http.Handler { return RequireKeycloakDPoPAdmin(cfg, hh) }

--- a/cds_service/internal/http/routes_test.go
+++ b/cds_service/internal/http/routes_test.go
@@ -34,6 +34,7 @@ func newTestRouter() http.Handler {
 // Helper to check status code
 func assertStatus(t *testing.T, router http.Handler, method, path string, want int) {
 	req := httptest.NewRequest(method, path, nil)
+	req.RemoteAddr = "127.0.0.1:12345"
 	rr := httptest.NewRecorder()
 
 	router.ServeHTTP(rr, req)
@@ -73,6 +74,58 @@ func TestDeviceLookupMethodEnforcement(t *testing.T) {
 
 	// Unsupported method → 405
 	assertStatus(t, r, "POST", "/v1/devices/abc", http.StatusMethodNotAllowed)
+}
+
+func TestDeviceLookupTrustedProxyRequirement(t *testing.T) {
+	cfg := &config.Config{
+		AuthMode:               "keycloak-dpop",
+		KeycloakIssuerURL:      "https://issuer.example/realms/cds",
+		KeycloakJWKSURL:        "http://127.0.0.1/keys",
+		KeycloakAudience:       "cds-service",
+		KeycloakRequiredRole:   "cds-admin",
+		KeycloakAdminUIClient:  "cds-admin-ui",
+		DPoPRequired:           true,
+		DPoPJtiCacheTTLSeconds: 300,
+		DPoPProofMaxAgeSeconds: 300,
+		DPoPClockSkewSeconds:   30,
+		JWKSCacheTTLSeconds:    300,
+		TrustedProxyCIDRs:      []string{"127.0.0.1/32"},
+	}
+	mtlsOnly := RequireClientCert(cfg, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	t.Run("trusted remote with SUCCESS is allowed by mTLS middleware", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/devices/abc", nil)
+		req.RemoteAddr = "127.0.0.1:12345"
+		req.Header.Set("X-SSL-Client-Verify", "SUCCESS")
+		rr := httptest.NewRecorder()
+		mtlsOnly.ServeHTTP(rr, req)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("got %d want %d", rr.Code, http.StatusNoContent)
+		}
+	})
+
+	t.Run("trusted remote without SUCCESS is rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/devices/abc", nil)
+		req.RemoteAddr = "127.0.0.1:12345"
+		rr := httptest.NewRecorder()
+		mtlsOnly.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("got %d want %d", rr.Code, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("untrusted remote cannot spoof SUCCESS", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/devices/abc", nil)
+		req.RemoteAddr = "203.0.113.10:12345"
+		req.Header.Set("X-SSL-Client-Verify", "SUCCESS")
+		rr := httptest.NewRecorder()
+		mtlsOnly.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("got %d want %d", rr.Code, http.StatusUnauthorized)
+		}
+	})
 }
 
 // Optional: test unknown route

--- a/cds_service/internal/http/routes_test.go
+++ b/cds_service/internal/http/routes_test.go
@@ -21,6 +21,8 @@ func newTestRouter() http.Handler {
 		KeycloakAudience:       "cds-service",
 		KeycloakRequiredRole:   "cds-admin",
 		KeycloakAdminUIClient:  "cds-admin-ui",
+		KeycloakAccessTokenAlg: "RS256",
+		DPoPAllowedAlgs:        []string{"ES256", "RS256"},
 		DPoPRequired:           true,
 		DPoPJtiCacheTTLSeconds: 300,
 		DPoPProofMaxAgeSeconds: 300,

--- a/cds_service/internal/http/routes_test.go
+++ b/cds_service/internal/http/routes_test.go
@@ -13,9 +13,20 @@ import (
 )
 
 // Create router for testing
-func newTestRouter() *http.ServeMux {
+func newTestRouter() http.Handler {
 	cfg := &config.Config{
-		ValidateTokenURL: "http://127.0.0.1/validate",
+		AuthMode:               "keycloak-dpop",
+		KeycloakIssuerURL:      "https://issuer.example/realms/cds",
+		KeycloakJWKSURL:        "http://127.0.0.1/keys",
+		KeycloakAudience:       "cds-service",
+		KeycloakRequiredRole:   "cds-admin",
+		KeycloakAdminUIClient:  "cds-admin-ui",
+		DPoPRequired:           true,
+		DPoPJtiCacheTTLSeconds: 300,
+		DPoPProofMaxAgeSeconds: 300,
+		DPoPClockSkewSeconds:   30,
+		JWKSCacheTTLSeconds:    300,
+		TrustedProxyCIDRs:      []string{"10.0.0.0/8", "127.0.0.1/32"},
 	}
 	return NewRouterWithConfig(cfg, nil)
 }
@@ -43,11 +54,11 @@ func TestHealth(t *testing.T) {
 func TestAdminMethodEnforcement(t *testing.T) {
 	r := newTestRouter()
 
-	// Allowed methods reach middleware but fail auth (no token)
-	assertStatus(t, r, "GET", "/v1/device", http.StatusForbidden)
-	assertStatus(t, r, "POST", "/v1/device", http.StatusForbidden)
-	assertStatus(t, r, "PUT", "/v1/device", http.StatusForbidden)
-	assertStatus(t, r, "DELETE", "/v1/device", http.StatusForbidden)
+	// Allowed methods reach middleware but fail auth (no Authorization)
+	assertStatus(t, r, "GET", "/v1/device", http.StatusUnauthorized)
+	assertStatus(t, r, "POST", "/v1/device", http.StatusUnauthorized)
+	assertStatus(t, r, "PUT", "/v1/device", http.StatusUnauthorized)
+	assertStatus(t, r, "DELETE", "/v1/device/abc", http.StatusUnauthorized)
 
 	// Unsupported method → 405
 	assertStatus(t, r, "PATCH", "/v1/device", http.StatusMethodNotAllowed)
@@ -68,4 +79,31 @@ func TestDeviceLookupMethodEnforcement(t *testing.T) {
 func TestUnknownRoute(t *testing.T) {
 	r := newTestRouter()
 	assertStatus(t, r, "GET", "/unknown", http.StatusNotFound)
+}
+
+func TestRequestIDGeneratedWhenAbsent(t *testing.T) {
+	r := newTestRouter()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /health got %d", rr.Code)
+	}
+	if rr.Header().Get("X-Request-Id") == "" {
+		t.Fatalf("expected X-Request-Id to be set")
+	}
+}
+
+func TestRequestIDPropagatedWhenProvided(t *testing.T) {
+	r := newTestRouter()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("X-Request-Id", "req-123")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /health got %d", rr.Code)
+	}
+	if got := rr.Header().Get("X-Request-Id"); got != "req-123" {
+		t.Fatalf("expected propagated request id, got %q", got)
+	}
 }

--- a/cds_service/internal/services/devices.go
+++ b/cds_service/internal/services/devices.go
@@ -21,7 +21,7 @@ func (s *DeviceService) Lookup(serial string) (string, error) {
 	return s.repo.GetEndpointBySerial(context.Background(), serial)
 }
 
-// Admin-facing (scoped by owner token)
+// Admin-facing (scoped by owner scope)
 func (s *DeviceService) AddOwned(serial, controllerEndpoint, owner string) error {
 	return s.repo.AddDevice(context.Background(), serial, controllerEndpoint, owner)
 }
@@ -34,4 +34,3 @@ func (s *DeviceService) DeleteOwned(serial, owner string) error {
 func (s *DeviceService) ListByOwner(owner string) ([]map[string]string, error) {
 	return s.repo.ListDevicesByOwner(context.Background(), owner)
 }
-


### PR DESCRIPTION
**Related issues:**
routerarchitects/ra-cds-service#12

**Summary**

Update `ra-cds-service` to migrate CDS admin API authentication from legacy `X-Auth-Token` validation to Keycloak-issued DPoP-bound access token validation, aligned with the merged `cds-service.yaml` contract.

Admin APIs now require:

- `Authorization: DPoP <keycloak_access_token>`
- `DPoP: <dpop_proof_jwt>`

Device-facing APIs continue to use the existing mTLS/nginx verification path. The health endpoint remains unchanged.

**What changed**

**Keycloak DPoP admin authentication**

- Added local Keycloak JWT validation using cached JWKS.
- Added unknown `kid` handling with one JWKS refresh and one validation retry.
- Removed normal admin-request dependency on OWSEC/introspection.
- Added role validation using `resource_access[keycloakAudience].roles`.
- Replaced legacy admin auth middleware with Keycloak DPoP admin middleware.
- Rejected `X-Auth-Token` as an admin auth path.

**DPoP validation**

Added validation for:

- DPoP proof signature
- `htm`
- `htu`
- `iat`
- `ath`
- `jti` replay protection
- `cnf.jkt` thumbprint binding

Also added trusted proxy handling for externally visible `htu` reconstruction using `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port` only when the remote address is trusted. The `Forwarded` header is ignored.

**API and ownership updates**

- Changed delete API to `DELETE /v1/device/{serial}`.
- Updated admin ownership to use `owner_scope`.
- Fresh schema now creates `owner_scope` directly.
- Existing deployments must create `devices.owner_scope` before running this version.
- No in-app `owner_token` → `owner_scope` migration is included.

**Production-safe logging**

- Added HTTP access logs with method, path, status, latency, remote address, and request ID.
- Added request ID generation/propagation using `X-Request-Id`.
- Added safe auth/JWKS logs using reason categories only.
- No raw tokens, DPoP proofs, Authorization headers, private keys, DSNs, secrets, or full JWT claims are logged.

**README and CI updates**

- Updated README examples for Keycloak DPoP auth.
- Updated DELETE example to use `/v1/device/{serial}`.
- Documented required auth configuration.
- Updated CI to run tests with PostgreSQL and DPoP auth environment variables.

**Impact**

- Admin clients must stop using `X-Auth-Token`.
- Admin clients must send both Keycloak DPoP access token and DPoP proof.
- Delete clients must use `DELETE /v1/device/{serial}`.
- Device-facing API behavior remains unchanged.
- Device-facing lookup remains global for any successfully mTLS-verified device certificate.
- This PR does not bind the verified certificate identity to the requested `{serial}`.
- Per-device certificate-to-serial authorization will be handled in a follow-up PR.
- DPoP replay protection currently uses an in-memory `jti` cache and is supported for single-instance CDS deployments.
- Multi-instance deployments require a shared replay cache, such as Redis, and will be handled as follow-up hardening. 
- Health endpoint behavior remains unchanged.

**Breaking change**

- `X-Auth-Token` is no longer accepted for admin API authorization.
- `DELETE /v1/device` is no longer the successful delete path.
- Clients should migrate to:
  - `Authorization: DPoP <keycloak_access_token>`
  - `DPoP: <dpop_proof_jwt>`
  - `DELETE /v1/device/{serial}`

**Tests added / updated**

- Added focused JWT and DPoP negative/security tests.
- Added unknown `kid` JWKS refresh success/failure tests.
- Added replay protection and trusted proxy `htu` reconstruction tests.
- Added route behavior tests for new auth contract and request ID handling.
- Updated integration test to use:
  - real router/middleware/handler/service/repo stack
  - real PostgreSQL test DB
  - fake JWKS server
  - generated access tokens
  - generated DPoP proofs
- Integration flow covers create, list, device-facing lookup, update, delete, and final list verification.

**Validation**

- `gofmt`, `go mod tidy`, `go test ./...`, `go vet ./...`, and `go build ./...` passed.
- Full PostgreSQL-backed integration suite passed locally.
- Integration tests executed and were not skipped.

**Review feedback addressed**

- Added full security/negative coverage for JWT and DPoP validation.
- Added real Postgres CRUD integration coverage with fake JWKS and generated tokens/proofs.
- Added production-safe structured request/auth logging.
- Confirmed no raw tokens/proofs/secrets are logged.


**Review Reference**

- Changes should align with:  
  https://github.com/routerarchitects/mango-cloud-yaml/blob/main/CDS-YAML/cds-service.yaml